### PR TITLE
require mediawiki-replaceable-content 0.2.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,7 +26,7 @@ jobs:
     # uses: ruby/setup-ruby@v1
       uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
       with:
-        ruby-version: 2.4
+        ruby-version: 2.5
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ AllCops:
   Exclude:
     - 'Vagrantfile'
     - 'vendor/**/*'
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: enable
 
 Metrics/AbcSize:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+# [1.3.4] - 2020-09-01
+
+## Fixes
+
+* Update to latest version of mediawiki-replaceable-content to include
+  upstream bug fix.
+
+# [1.3.3] - 2020-08-29
+
+## Enhancements
+
+* Include link to Wikidata Query Service showing the SPARQL used to
+  generate the list.
+
 # [1.3.2] - 2020-08-29
 
 ## Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     kwalify (0.7.2)
-    mediawiki-page-replaceable_content (0.1.3)
+    mediawiki-replaceable-content (0.2.1)
       mediawiki_api (~> 0.7)
     mediawiki_api (0.7.1)
       faraday (~> 0.9, >= 0.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    wikidata_position_history (1.3.3)
-      mediawiki-page-replaceable_content (= 0.1.3)
+    wikidata_position_history (1.3.4)
+      mediawiki-replaceable-content (= 0.2.1)
       rest-client (~> 2.0)
 
 GEM

--- a/exe/update_wikidata_page
+++ b/exe/update_wikidata_page
@@ -17,7 +17,7 @@ if ARGV.first.start_with?('http')
     page_title:     uri.path.gsub('/wiki/', ''), # with 2.5.1 we could use delete_prefix
   }
 else
-  options = URI.decode_www_form(ARGV.first).map { |k, v| [k.to_sym, v] }.to_h
+  options = URI.decode_www_form(ARGV.first).transform_keys(&:to_sym)
 end
 
 warn "Running with options: #{options.inspect}" if ENV.key?('DEBUG')

--- a/lib/wikidata_position_history/version.rb
+++ b/lib/wikidata_position_history/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WikidataPositionHistory
-  VERSION = '1.3.3'
+  VERSION = '1.3.4'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,9 @@ Gem.path.each do |path|
   Warning.ignore(//, path)
 end
 
+ENV['WIKI_USERNAME'] = 'test'
+ENV['WIKI_PASSWORD'] = 'test'
+
 require 'minitest/autorun'
 require 'pry'
 require 'webmock/minitest'

--- a/wikidata_position_history.gemspec
+++ b/wikidata_position_history.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'wikidata_position_history/version'
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
   spec.name                  = 'wikidata_position_history'
   spec.version               = WikidataPositionHistory::VERSION
   spec.authors               = ['Tony Bowden', 'Mark Longair']

--- a/wikidata_position_history.gemspec
+++ b/wikidata_position_history.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'mediawiki-page-replaceable_content', '0.1.3'
+  spec.add_runtime_dependency 'mediawiki-replaceable-content', '0.2.1'
   spec.add_runtime_dependency 'rest-client', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 2.1'


### PR DESCRIPTION
This version allows percentage signs in the output, which is necessary to include the WDQS link.