### PR TITLE
Test full output rather than start/end

### DIFF
--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -35,7 +35,7 @@ module WikidataPositionHistory
 
     def ordinal_string
       ordinal = current.ordinal or return ''
-      ordinal.concat('.')
+      "#{ordinal}."
     end
 
     def member_style

--- a/test/Q14211.out
+++ b/test/Q14211.out
@@ -1,0 +1,303 @@
+== {{Q|Q14211}} officeholders (1721-04-04 – ) ==
+{| class="wikitable" style="text-align: center; border: none;"
+|-
+| style="padding:0.5em 2em" | 76.
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q264766}}</span> 2016-07-13 – 
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q192}}</span> 2010-05-11 – 2016-07-13
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 74.
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q10648}}</span> 2007-06-27 – 2010-05-11
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 73.
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q9545}}</span> 1997-05-02 – 2007-06-27
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 72.
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q9559}}</span> 1990-11-28 – 1997-05-02
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q7416}}</span> 1979-05-04 – 1990-11-28
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q9576}}</span> 1976-04-05 – 1979-05-04
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q128956}}</span> 1974-03-04 – 1976-04-05
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q128967}}</span> 1970-06-19 – 1974-03-04
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q128956}}</span> 1964-10-16 – 1970-06-19
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q128976}}</span> 1963-10-19 – 1964-10-16
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q128985}}</span> 1957-01-10 – 1963-10-19
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q128995}}</span> 1955-04-07 – 1957-01-10
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q8016}}</span> 1951-10-26 – 1955-04-07
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q129006}}</span> 1945-07-26 – 1951-10-26
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q8016}}</span> 1940-05-10 – 1945-07-26
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q10664}}</span> 1937-05-28 – 1940-05-10
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q166635}}</span> 1935-06-07 – 1937-05-28
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q166646}}</span> 1929-06-05 – 1935-06-07
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q166635}}</span> 1924-11-04 – 1929-06-05
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q166646}}</span> 1924-01-22 – 1924-11-04
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q166635}}</span> 1923-05-23 – 1924-01-16
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q166663}}</span> 1922-10-23 – 1923-05-22
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q134982}}</span> 1916-12-06 – 1922-10-19
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q166714}}</span> 1908-04-05 – 1916-12-05
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q106618}}</span> 1905-12-05 – 1908-04-03
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q19008}}</span> 1902-07-11 – 1905-12-05
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q243705}}</span> 1895-06-25 – 1902-07-11
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q244620}}</span> 1894-03-05 – 1895-06-22
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q160852}}</span> 1892-08-15 – 1894-03-02
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q243705}}</span> 1886-07-25 – 1892-08-11
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q160852}}</span> 1886-02-01 – 1886-07-20
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q243705}}</span> 1885-06-23 – 1886-01-28
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q160852}}</span> 1880-04-23 – 1885-06-09
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q82006}}</span> 1874-02-20 – 1880-04-21
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q160852}}</span> 1868-12-03 – 1874-02-17
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q82006}}</span> 1868-02-27 – 1868-12-01
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q237829}}</span> 1866-06-28 – 1868-02-27
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q157259}}</span> 1865-10-29 – 1866-06-28
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q193656}}</span> 1859-06-12 – 1865-10-18
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q237829}}</span> 1858-02-20 – 1859-06-11
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q193656}}</span> 1855-02-06 – 1858-02-19
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q24631}}</span> 1852-12-19 – 1855-01-30
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q237829}}</span> 1852-02-23 – 1852-12-19
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q157259}}</span> 1846-06-30 – 1852-02-23
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q181875}}</span> 1841-08-30 – 1846-06-29
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Inconsistent predecessor</span>&nbsp;<ref>{{Q|Q181875}} has a {{P|1365}} of {{Q|Q312567}}, which differs from {{Q|Q181875}}</ref></span>
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q181875}}</span> 1834-12-10 – 1835-04-08
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Inconsistent predecessor</span>&nbsp;<ref>{{Q|Q181875}} has a {{P|1365}} of {{Q|Q131691}}, which differs from {{Q|Q312567}}</ref></span><span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Inconsistent successor</span>&nbsp;<ref>{{Q|Q181875}} has a {{P|1366}} of {{Q|Q312567}}, which differs from {{Q|Q181875}}</ref></span>
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q312567}}</span> 1834-07-16 – 1834-11-14
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Inconsistent predecessor</span>&nbsp;<ref>{{Q|Q312567}} has a {{P|1365}} of {{Q|Q181875}}, which differs from {{Q|Q294662}}</ref></span><span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Inconsistent successor</span>&nbsp;<ref>{{Q|Q312567}} has a {{P|1366}} of {{Q|Q131691}}, which differs from {{Q|Q181875}}</ref></span>
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q294662}}</span> 1830-11-22 – 1834-07-16
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q131691}}</span> 1828-01-22 – 1830-11-16
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q312591}}</span> 1827-08-31 – 1828-01-21
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q219731}}</span> 1827-04-10 – 1827-08-08
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q312569}}</span> 1812-06-08 – 1827-04-09
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q233992}}</span> 1809-10-04 – 1812-05-11
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q157208}}</span> 1807-03-31 – 1809-10-04
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q312596}}</span> 1806-02-11 – 1807-03-31
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q128902}}</span> 1804-05-10 – 1806-01-23
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q312577}}</span> 1801-03-14 – 1804-05-10
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q128902}}</span> 1801-01-01 – 1801-03-14
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Missing field</span>&nbsp;<ref>{{Q|Q128902}} is missing {{P|1365}}</ref></span>
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q157208}}</span> 1783-04-02 – 1783-12-19
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q312573}}</span> 1782-07-04 – 1783-04-02
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q378043}}</span> 1782-03-27 – 1782-07-01
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q312593}}</span> 1770-01-28 – 1782-03-22
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q312583}}</span> 1768-10-14 – 1770-01-28
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q208663}}</span> 1766-07-30 – 1768-10-14
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q378043}}</span> 1765-07-13 – 1766-07-30
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q244616}}</span> 1763-04-16 – 1765-07-13
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q294651}}</span> 1762-05-26 – 1763-04-08
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q273809}}</span> 1757-07-02 – 1762-05-26
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q238639}}</span> 1756-11-16 – 1757-06-25
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q273809}}</span> 1754-03-16 – 1756-11-16
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q244766}}</span> 1743-08-27 – 1754-03-06
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q270415}}</span> 1742-02-16 – 1743-07-02
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q104190}}</span> 1721-04-15 – 1742-02-27
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Date overlap</span>&nbsp;<ref>{{Q|Q104190}} has a {{P|582}} of 1742-02-27, which is later than the {{P|580}} of 1742-02-16 for {{Q|Q270415}}</ref></span>
+|}
+
+<div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
+  <div style="float:right">[https://query.wikidata.org/#%23%20position-mandates%0A%0ASELECT%20DISTINCT%20%3Fordinal%20%3Fitem%20%3Fstart_date%20%3Fstart_precision%20%3Fend_date%20%3Fend_precision%20%3Fprev%20%3Fnext%20%3Fnature%0AWHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%20wd%3AQ5%20%3B%20p%3AP39%20%3Fposn%20.%0A%20%20%3Fposn%20ps%3AP39%20wd%3AQ14211%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fposn%20wikibase%3Arank%20wikibase%3ADeprecatedRank%20%7D%0A%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP580%20%5B%20wikibase%3AtimeValue%20%3Fstart_date%3B%20wikibase%3AtimePrecision%20%3Fstart_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP582%20%5B%20wikibase%3AtimeValue%20%3Fend_date%3B%20wikibase%3AtimePrecision%20%3Fend_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1365%7Cpq%3AP155%20%3Fprev%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1366%7Cpq%3AP156%20%3Fnext%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1545%20%3Fordinal%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP5102%20%3Fnature%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fstart_date%29%0A WDQS]</div>
+</div>

--- a/test/wikidata_position_history/wikitext_test.rb
+++ b/test/wikidata_position_history/wikitext_test.rb
@@ -2,54 +2,17 @@
 
 require 'test_helper'
 
-EXPECTED_START = <<~WIKITEXT
-  {| class="wikitable" style="text-align: center; border: none;"
-  |-
-  | style="padding:0.5em 2em" | 76.
-  | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q264766}}</span> 2016-07-13 – 
-  | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
-  |-
-  | style="padding:0.5em 2em" | 
-  | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q192}}</span> 2010-05-11 – 2016-07-13
-  | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
-WIKITEXT
-
-EXPECTED_END = <<~WIKITEXT
-  |-
-  | style="padding:0.5em 2em" | 
-  | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q270415}}</span> 1742-02-16 – 1743-07-02
-  | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
-  |-
-  | style="padding:0.5em 2em" | 
-  | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q104190}}</span> 1721-04-15 – 1742-02-27
-  | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Date overlap</span>&nbsp;<ref>{{Q|Q104190}} has a {{P|582}} of 1742-02-27, which is later than the {{P|580}} of 1742-02-16 for {{Q|Q270415}}</ref></span>
-  |}
-
-  <div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
-    <div style="float:right">[https://query.wikidata.org/#%23%20position-mandates%0A%0ASELECT%20DISTINCT%20%3Fordinal%20%3Fitem%20%3Fstart_date%20%3Fstart_precision%20%3Fend_date%20%3Fend_precision%20%3Fprev%20%3Fnext%20%3Fnature%0AWHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%20wd%3AQ5%20%3B%20p%3AP39%20%3Fposn%20.%0A%20%20%3Fposn%20ps%3AP39%20wd%3AQ14211%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fposn%20wikibase%3Arank%20wikibase%3ADeprecatedRank%20%7D%0A%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP580%20%5B%20wikibase%3AtimeValue%20%3Fstart_date%3B%20wikibase%3AtimePrecision%20%3Fstart_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP582%20%5B%20wikibase%3AtimeValue%20%3Fend_date%3B%20wikibase%3AtimePrecision%20%3Fend_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1365%7Cpq%3AP155%20%3Fprev%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1366%7Cpq%3AP156%20%3Fnext%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1545%20%3Fordinal%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP5102%20%3Fnature%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fstart_date%29%0A WDQS]</div>
-  </div>
-WIKITEXT
+# This is just a very high level acceptance test at the moment - not
+# very useful for locating where a bug might be, but somewhat
+# helpful as a test of whether something's broken.
 
 describe 'wikitext_history' do
   before { use_sample_data }
-
   subject { WikidataPositionHistory::Report.new('Q14211') }
 
-  # This is just a very high level acceptance test at the moment - not
-  # very useful for locating where a bug might be, but somewhat
-  # helpful as a test of whether something's broken.
+  let(:expected) { Pathname.new('test/Q14211.out').read }
+
   it 'generates wikitext that starts how we expect' do
-    expected_start = EXPECTED_START
-    expect(subject.wikitext[0...expected_start.length]).must_equal expected_start
-  end
-
-  it 'generates wikitext that ends how we expect' do
-    expected_end = EXPECTED_END
-    expect(subject.wikitext[-expected_end.length..-1]).must_equal expected_end
-  end
-
-  it 'starts how we expect with include_header set to true' do
-    expected_start = "== {{Q|Q14211}} officeholders (1721-04-04 – ) ==\n#{EXPECTED_START}"
-    expect(subject.wikitext_with_header[0...expected_start.length]).must_equal expected_start
+    expect(subject.wikitext_with_header).must_equal expected
   end
 end


### PR DESCRIPTION
It's much safer, and much easier to follow what's going on if we have
one full end-to-end test for the expected output, rather than looking
solely at the start and end of it.