### PR TITLE
[refactoring] Move output to a template

### DIFF
--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -26,10 +26,8 @@ module WikidataPositionHistory
       dates.join(' – ')
     end
 
-    def style
-      return 'font-size: 1.25em; display: block; font-style: italic;' if current.acting?
-
-      'font-size: 1.5em; display: block;'
+    def acting?
+      current.acting?
     end
 
     def warnings

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WikidataPositionHistory
-  # A single output row of Wikitext for an officeholding
+  # Date for a single mandate row, to be passed to the report template
   class MandateData
     def initialize(later, current, earlier)
       @later = later
@@ -31,21 +31,12 @@ module WikidataPositionHistory
     end
 
     def warnings
-      CHECKS.map do |check_class|
-        check = check_class.new(later, current, earlier)
-        format(WARNING_LAYOUT, check.headline, check.explanation) if check.problem?
-      end.join
+      CHECKS.map { |klass| klass.new(later, current, earlier) }.select(&:problem?)
     end
 
     private
 
     CHECKS = [Check::MissingFields, Check::WrongPredecessor, Check::WrongSuccessor, Check::Overlap].freeze
-
-    WARNING_LAYOUT = [
-      '<span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;',
-      '<span style="color: #d33; font-weight: bold; vertical-align: middle;">%s</span>&nbsp;',
-      '<ref>%s</ref></span>'
-    ].join
 
     attr_reader :later, :current, :earlier
   end

--- a/report.erb
+++ b/report.erb
@@ -2,7 +2,7 @@
 <% table_rows.each do |mandate| %>|-
 | style="padding:0.5em 2em" | <%= mandate.ordinal_string %>
 | style="padding:0.5em 2em" | <span style="font-size: <%= mandate.acting? ? '1.25em; font-style: italic;' : '1.5em' %>; display: block;"><%= mandate.person %></span> <%= mandate.dates %>
-| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <%= mandate.warnings %>
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <% mandate.warnings.each do |warning| %><span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span><% end %>
 <% end %>|}
 
 <div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">

--- a/report.erb
+++ b/report.erb
@@ -1,0 +1,7 @@
+{| class="wikitable" style="text-align: center; border: none;"
+<%= table_rows.join("\n") %>
+|}
+
+<div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
+  <div style="float:right">[<%= sparql_url %> WDQS]</div>
+</div>

--- a/report.erb
+++ b/report.erb
@@ -1,7 +1,7 @@
 {| class="wikitable" style="text-align: center; border: none;"
 <% table_rows.each do |mandate| %>|-
 | style="padding:0.5em 2em" | <%= mandate.ordinal_string %>
-| style="padding:0.5em 2em" | <span style="<%= mandate.style %>"><%= mandate.person %></span> <%= mandate.dates %>
+| style="padding:0.5em 2em" | <span style="font-size: <%= mandate.acting? ? '1.25em; font-style: italic;' : '1.5em' %>; display: block;"><%= mandate.person %></span> <%= mandate.dates %>
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <%= mandate.warnings %>
 <% end %>|}
 

--- a/report.erb
+++ b/report.erb
@@ -1,6 +1,9 @@
 {| class="wikitable" style="text-align: center; border: none;"
-<%= table_rows.join("\n") %>
-|}
+<% table_rows.each do |mandate| %>|-
+| style="padding:0.5em 2em" | <%= mandate.ordinal_string %>
+| style="padding:0.5em 2em" | <span style="<%= mandate.style %>"><%= mandate.person %></span> <%= mandate.dates %>
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <%= mandate.warnings %>
+<% end %>|}
 
 <div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
   <div style="float:right">[<%= sparql_url %> WDQS]</div>


### PR DESCRIPTION
Rather than intermingling the output wikitext into the Report class, pull it out into an ERB template.