### PR TITLE
Require mediawiki-replaceable-content 0.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     wikidata_position_history (1.4.1)
-      mediawiki-replaceable-content (= 0.2.1)
+      mediawiki-replaceable-content (= 0.2.2)
       rest-client (~> 2.0)
 
 GEM
@@ -28,7 +28,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     kwalify (0.7.2)
-    mediawiki-replaceable-content (0.2.1)
+    mediawiki-replaceable-content (0.2.2)
       mediawiki_api (~> 0.7)
     mediawiki_api (0.7.1)
       faraday (~> 0.9, >= 0.9.0)

--- a/wikidata_position_history.gemspec
+++ b/wikidata_position_history.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'mediawiki-replaceable-content', '0.2.1'
+  spec.add_runtime_dependency 'mediawiki-replaceable-content', '0.2.2'
   spec.add_runtime_dependency 'rest-client', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 2.1'


### PR DESCRIPTION
This version fixes an encoding bug