### PR TITLE
Turn on rubocop's Layout/ClassStructure check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,3 +54,6 @@ Style/TrailingCommaInHashLiteral:
 
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: no_comma
+
+Layout/ClassStructure:
+  Enabled: true

--- a/lib/wikidata_position_history.rb
+++ b/lib/wikidata_position_history.rb
@@ -22,6 +22,19 @@ module WikidataPositionHistory
     WIKI_USERNAME = ENV['WIKI_USERNAME']
     WIKI_PASSWORD = ENV['WIKI_PASSWORD']
 
+    NO_ID_ERROR = <<~WIKITEXT
+      '''#{WIKI_TEMPLATE_NAME} Error''': You must pass the <code>id</code>
+      parameter to the <code>#{WIKI_TEMPLATE_NAME}</code> template; e.g.
+      <nowiki>{{#{WIKI_TEMPLATE_NAME}|id=Q14211}}</nowiki>
+    WIKITEXT
+
+    MALFORMED_ID_ERROR = <<~WIKITEXT
+      '''#{WIKI_TEMPLATE_NAME} Error''': The <code>id</code> parameter was
+      malformed; it should be Q followed by a number of digits, e.g. as in:
+
+      <nowiki>{{#{WIKI_TEMPLATE_NAME}|id=Q14211}}</nowiki>
+    WIKITEXT
+
     def initialize(mediawiki_site:, page_title:)
       @mediawiki_site = mediawiki_site
       @page_title = page_title.tr('_', ' ')
@@ -41,19 +54,6 @@ module WikidataPositionHistory
     private
 
     attr_reader :mediawiki_site, :page_title
-
-    NO_ID_ERROR = <<~EOERROR
-      '''#{WIKI_TEMPLATE_NAME} Error''': You must pass the <code>id</code>
-      parameter to the <code>#{WIKI_TEMPLATE_NAME}</code> template; e.g.
-      <nowiki>{{#{WIKI_TEMPLATE_NAME}|id=Q14211}}</nowiki>
-    EOERROR
-
-    MALFORMED_ID_ERROR = <<~EOERROR
-      '''#{WIKI_TEMPLATE_NAME} Error''': The <code>id</code> parameter was
-      malformed; it should be Q followed by a number of digits, e.g. as in:
-
-      <nowiki>{{#{WIKI_TEMPLATE_NAME}|id=Q14211}}</nowiki>
-    EOERROR
 
     def position_id
       return id_param unless id_param.empty?

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -3,6 +3,8 @@
 module WikidataPositionHistory
   # Date for a single mandate row, to be passed to the report template
   class MandateData
+    CHECKS = [Check::MissingFields, Check::WrongPredecessor, Check::WrongSuccessor, Check::Overlap].freeze
+
     def initialize(later, current, earlier)
       @later = later
       @current = current
@@ -35,8 +37,6 @@ module WikidataPositionHistory
     end
 
     private
-
-    CHECKS = [Check::MissingFields, Check::WrongPredecessor, Check::WrongSuccessor, Check::Overlap].freeze
 
     attr_reader :later, :current, :earlier
   end


### PR DESCRIPTION
This is turned off by default, but is worth turning on to ensure a consistent code layout.