### PR TITLE
Make sure that missing dates are reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# [1.4.2] 2020-09-05
+
+## Fixes
+
+* Bring back the warnings when start or end dates are missing.
+
 # [1.4.1] 2020-09-04
 
 ## Fixes

--- a/lib/sparql/mandates.rb
+++ b/lib/sparql/mandates.rb
@@ -63,10 +63,14 @@ module WikidataPositionHistory
     end
 
     def start_date
+      return if start_date_raw.empty?
+
       QueryService::WikidataDate.new(start_date_raw, start_date_precision)
     end
 
     def end_date
+      return if end_date_raw.empty?
+
       QueryService::WikidataDate.new(end_date_raw, end_date_precision)
     end
 

--- a/lib/wikidata_position_history/checks.rb
+++ b/lib/wikidata_position_history/checks.rb
@@ -124,9 +124,7 @@ module WikidataPositionHistory
       def problem?
         return false unless later
 
-        ends = current.end_date
-        return false if ends.empty?
-
+        ends = current.end_date or return false
         ends > later.start_date
       rescue ArgumentError
         true

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -22,8 +22,7 @@ module WikidataPositionHistory
 
     def dates
       dates = [current.start_date, current.end_date]
-      # compact doesn't work here, even if we add #nil? to WikidataDate
-      return '' if dates.reject(&:empty?).empty?
+      return '' if dates.compact.empty?
 
       dates.join(' – ')
     end

--- a/lib/wikidata_position_history/version.rb
+++ b/lib/wikidata_position_history/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WikidataPositionHistory
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end

--- a/test/example-data/biodata/Q16147179.json
+++ b/test/example-data/biodata/Q16147179.json
@@ -1,0 +1,31 @@
+{
+  "head" : {
+    "vars" : [ "item", "image" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13124934"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Wasira%20pic%202012.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5553143"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6768990"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Mark%20Mwandosya.jpg"
+      }
+    } ]
+  }
+}

--- a/test/example-data/mandates/Q16147179.json
+++ b/test/example-data/mandates/Q16147179.json
@@ -1,0 +1,23 @@
+{
+  "head" : {
+    "vars" : [ "ordinal", "item", "start_date", "start_precision", "end_date", "end_precision", "prev", "next", "nature" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5553143"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6768990"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13124934"
+      }
+    } ]
+  }
+}

--- a/test/example-data/metadata/Q16147179.json
+++ b/test/example-data/metadata/Q16147179.json
@@ -1,0 +1,14 @@
+{
+  "head" : {
+    "vars" : [ "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      }
+    } ]
+  }
+}

--- a/test/wikidata_position_history/checks_spec.rb
+++ b/test/wikidata_position_history/checks_spec.rb
@@ -5,8 +5,10 @@ require 'test_helper'
 describe 'Checks' do
   before { use_sample_data }
 
+  let(:mandates) { WikidataPositionHistory::Report.new(position).send(:padded_mandates) }
+
   describe 'UK Prime Minister' do
-    let(:mandates) { WikidataPositionHistory::Report.new('Q14211').send(:padded_mandates) }
+    let(:position) { 'Q14211' }
 
     it 'allows for no successor for the incumbent' do
       check = WikidataPositionHistory::Check::WrongSuccessor.new(*mandates.take(3))
@@ -40,12 +42,11 @@ describe 'Checks' do
   end
 
   describe 'Prime Minister of Moldova' do
-    let(:mandates) { WikidataPositionHistory::Report.new('Q1769526').send(:padded_mandates) }
+    let(:position) { 'Q1769526' }
 
     it 'warns of missing replaced_by' do
       check = WikidataPositionHistory::Check::MissingFields.new(*mandates.last(3))
-      expect(check.problem?).must_equal true
-      expect(check.explanation).must_include '{{P|1366}}'
+      expect(check.explanation.scan(/{{P\|(\d+)}}/).flatten).must_equal %w[1366]
     end
 
     it 'does not warn of missing succession if followed by self' do
@@ -57,7 +58,7 @@ describe 'Checks' do
   end
 
   describe 'Albanian Ambassador' do
-    let(:mandates) { WikidataPositionHistory::Report.new('Q56761097').send(:padded_mandates) }
+    let(:position) { 'Q56761097' }
 
     it 'warns of imprecise dates that may overlap' do
       landsman = mandates.index { |result| result&.ordinal == '9' }

--- a/test/wikidata_position_history/checks_spec.rb
+++ b/test/wikidata_position_history/checks_spec.rb
@@ -67,4 +67,14 @@ describe 'Checks' do
       expect(check.headline).must_equal('Date precision')
     end
   end
+
+  # Three officeholders, with no qualifiers at all
+  describe 'Tanzanian Water Minister' do
+    let(:position) { 'Q16147179' }
+
+    it 'warns of missing start and end dates' do
+      check = WikidataPositionHistory::Check::MissingFields.new(*mandates.drop(1).take(3))
+      expect(check.explanation.scan(/{{P\|(\d+)}}/).flatten.sort).must_equal %w[1365 1366 580 582]
+    end
+  end
 end


### PR DESCRIPTION
Having 'empty' date objects was proving problematic in lots of places, so
return to having these be nil if there is no information.