### PR TITLE
Speed up the position metadata query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# Unrelased
+
+# Improvements
+
+* A query like https://w.wiki/bVz is taking about 6 seconds to run.
+  Changing that to https://w.wiki/bW3 drops that to about half a second.
+  If you were to guess that the first has now been replaced by the
+  second, you'd be entirely correct.
+
 # [1.6.0] 2020-09-07
 
 ## Enhancements

--- a/lib/sparql/item_query.rb
+++ b/lib/sparql/item_query.rb
@@ -23,7 +23,11 @@ module WikidataPositionHistory
       attr_reader :itemid
 
       def sparql
-        raw_sparql % itemid
+        raw_sparql % sparql_args
+      end
+
+      def sparql_args
+        itemid
       end
 
       def json

--- a/lib/sparql/position_data.rb
+++ b/lib/sparql/position_data.rb
@@ -11,12 +11,16 @@ module WikidataPositionHistory
           SELECT DISTINCT ?inception ?inception_precision ?abolition ?abolition_precision ?isPosition
           WHERE {
             VALUES ?item { wd:%s }
-            BIND(EXISTS { ?item wdt:P279+ wd:Q4164871  } as ?isPosition)
+            BIND(EXISTS { wd:%s wdt:P279+ wd:Q4164871  } as ?isPosition)
             OPTIONAL { ?item p:P571/psv:P571 [ wikibase:timeValue ?inception; wikibase:timePrecision ?inception_precision ] }
             OPTIONAL { ?item p:P576/psv:P576 [ wikibase:timeValue ?abolition; wikibase:timePrecision ?abolition_precision ] }
             SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
           }
         SPARQL
+      end
+
+      def sparql_args
+        [itemid, itemid]
       end
     end
   end


### PR DESCRIPTION
```sparql
 BIND ( wd:Q14211 AS ?item ).
 BIND(EXISTS { ?item wdt:P279+ wd:Q4164871  } as ?isPosition)
```

Is currently taking approx 6-8 seconds per query

Explicitly inlining the position ID drops that to about half a second:

```sparql
 BIND ( wd:Q14211 AS ?item ).
 BIND(EXISTS { wd:Q14211 wdt:P279+ wd:Q4164871  } as ?isPosition)
```

I don’t really know what’s going on with that, but as the daily update runs
this about 1250 times, those extra seconds add about an hour and a half.

So, switch to the second approach instead.