### PR TITLE
[refactoring] rename Query/Row classes

### DIFF
--- a/lib/sparql/bio_query.rb
+++ b/lib/sparql/bio_query.rb
@@ -7,7 +7,7 @@ module WikidataPositionHistory
     # This is distinct from the mandate query itself to avoid complex
     # GROUP BY scenarios where people have multiple values for
     # biographical properties.
-    class BioData < ItemQuery
+    class BioQuery < ItemQuery
       def raw_sparql
         <<~SPARQL
           # holder-biodata
@@ -24,7 +24,7 @@ module WikidataPositionHistory
   end
 
   # Represents a single row returned from the Position query
-  class BioData
+  class BioRow
     def initialize(row)
       @row = row
     end

--- a/lib/sparql/mandates_query.rb
+++ b/lib/sparql/mandates_query.rb
@@ -3,7 +3,7 @@
 module WikidataPositionHistory
   module SPARQL
     # SPARQL for fetching all officeholdings of a position
-    class Mandates < ItemQuery
+    class MandatesQuery < ItemQuery
       def raw_sparql
         <<~SPARQL
           # position-mandates
@@ -28,7 +28,7 @@ module WikidataPositionHistory
   end
 
   # Represents a single row returned from the Mandates query
-  class Mandate
+  class MandateRow
     def initialize(row)
       @row = row
     end

--- a/lib/sparql/position_query.rb
+++ b/lib/sparql/position_query.rb
@@ -3,7 +3,7 @@
 module WikidataPositionHistory
   module SPARQL
     # SPARQL for fetching metadata about a position
-    class PositionData < ItemQuery
+    class PositionQuery < ItemQuery
       def raw_sparql
         <<~SPARQL
           # position-metadata
@@ -26,7 +26,7 @@ module WikidataPositionHistory
   end
 
   # Represents a single row returned from the Position query
-  class PositionData
+  class PositionRow
     def initialize(row)
       @row = row
     end

--- a/lib/wikidata_position_history.rb
+++ b/lib/wikidata_position_history.rb
@@ -2,9 +2,9 @@
 
 require 'query_service'
 require 'sparql/item_query'
-require 'sparql/position_data'
-require 'sparql/bio_data'
-require 'sparql/mandates'
+require 'sparql/position_query'
+require 'sparql/bio_query'
+require 'sparql/mandates_query'
 require 'wikidata_position_history/checks'
 require 'wikidata_position_history/template'
 require 'wikidata_position_history/report'

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -83,11 +83,11 @@ module WikidataPositionHistory
     def metadata
       # TODO: we might get more than one response, if a position has
       # multiple dates
-      @metadata ||= SPARQL::PositionData.new(position_id).results_as(PositionData).first
+      @metadata ||= SPARQL::PositionQuery.new(position_id).results_as(PositionRow).first
     end
 
     def biodata
-      @biodata ||= SPARQL::BioData.new(position_id).results_as(BioData)
+      @biodata ||= SPARQL::BioQuery.new(position_id).results_as(BioRow)
     end
 
     def biodata_for(officeholder)
@@ -99,11 +99,11 @@ module WikidataPositionHistory
     end
 
     def sparql
-      @sparql ||= SPARQL::Mandates.new(position_id)
+      @sparql ||= SPARQL::MandatesQuery.new(position_id)
     end
 
     def mandates
-      @mandates ||= sparql.results_as(Mandate)
+      @mandates ||= sparql.results_as(MandateRow)
     end
 
     def no_items_output


### PR DESCRIPTION
Make it much more obvious that these classes represent the SPARQL
Queries, and each row returned from those queries, rather than any
business-logic class that in turns wraps those up.