### PR TITLE
Display multiple inception or abolition dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # Unrelased
 
+# Enchancements
+
+* Yesterday’s future, when we said we'd do something a little better
+  with positions that have multiple inception or abolition dates, has
+  arrived. Now we display all of them, rather than just picking one
+  semi-randomly.
+
 # Improvements
 
 * A query like https://w.wiki/bVz is taking about 6 seconds to run.

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -68,11 +68,11 @@ module WikidataPositionHistory
     attr_reader :rows
 
     def inception_dates
-      rows.map(&:inception_date).compact.uniq
+      rows.map(&:inception_date).compact.uniq(&:to_s).sort
     end
 
     def abolition_dates
-      rows.map(&:abolition_date).compact.uniq
+      rows.map(&:abolition_date).compact.uniq(&:to_s).sort
     end
   end
 

--- a/test/create_example_data.rb
+++ b/test/create_example_data.rb
@@ -11,6 +11,6 @@ def store(id, dir, query)
 end
 
 id = ARGV.first or abort "Usage: #{$PROGRAM_NAME} <Qid>"
-store(id, 'mandates', WikidataPositionHistory::SPARQL::Mandates.new(id))
-store(id, 'metadata', WikidataPositionHistory::SPARQL::PositionData.new(id))
-store(id, 'biodata', WikidataPositionHistory::SPARQL::BioData.new(id))
+store(id, 'mandates', WikidataPositionHistory::SPARQL::MandatesQuery.new(id))
+store(id, 'metadata', WikidataPositionHistory::SPARQL::PositionQuery.new(id))
+store(id, 'biodata', WikidataPositionHistory::SPARQL::BioQuery.new(id))

--- a/test/example-data/biodata/Q3657870.json
+++ b/test/example-data/biodata/Q3657870.json
@@ -1,0 +1,31 @@
+{
+  "head" : {
+    "vars" : [ "item", "image" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51267"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q8620"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/The%20National%20Archives%20UK%20-%20CO%201069-50-1.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q8620"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/1989%20CPA%206101.jpg"
+      }
+    } ]
+  }
+}

--- a/test/example-data/mandates/Q3657870.json
+++ b/test/example-data/mandates/Q3657870.json
@@ -1,0 +1,62 @@
+{
+  "head" : {
+    "vars" : [ "ordinal", "item", "start_date", "start_precision", "end_date", "end_precision", "prev", "next", "nature" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51267"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1969-10-01T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1972-01-13T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q8620"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q8620"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1957-03-06T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1960-07-01T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    } ]
+  }
+}

--- a/test/example-data/metadata/Q3657870.json
+++ b/test/example-data/metadata/Q3657870.json
@@ -1,0 +1,112 @@
+{
+  "head" : {
+    "vars" : [ "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1960-01-01T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "9"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1969-01-01T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "9"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      }
+    }, {
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1972-01-01T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "9"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1957-01-01T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "9"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      }
+    }, {
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1972-01-01T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "9"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1969-01-01T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "9"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      }
+    }, {
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1960-01-01T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "9"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1957-01-01T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "9"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      }
+    } ]
+  }
+}

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -22,6 +22,13 @@ describe WikidataPositionHistory::Report do
     it { expect(metadata.abolition_date.to_s).must_equal '1945' }
   end
 
+  describe 'office with multiple inception and abolition dates' do
+    let(:position_id) { 'Q3657870' }
+
+    it { expect(metadata.inception_date.to_s).must_equal '1957 / 1969' }
+    it { expect(metadata.abolition_date.to_s).must_equal '1960 / 1972' }
+  end
+
   describe 'office with neither inception nor abolition date' do
     let(:position_id) { 'Q96424184' }
 


### PR DESCRIPTION
If a position has more than one inception or abolition dates, display all of them.

This doesn't yet raise a warning about this, but that should be added soon.

Before:
![Screen Shot 2020-09-08 at 09 39 24](https://user-images.githubusercontent.com/57483/92453532-478db580-f1b7-11ea-8611-698bdf16a8a3.png)

After:
![Screen Shot 2020-09-08 at 09 39 32](https://user-images.githubusercontent.com/57483/92453524-45c3f200-f1b7-11ea-8d20-bbd743e09099.png)
