### PR TITLE
Add warnings for position inception/abolition dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 * Yesterday’s future, when we said we'd do something a little better
   with positions that have multiple inception or abolition dates, has
-  arrived. Now we display all of them, rather than just picking one
-  semi-randomly.
+  arrived. Now we display all of them (with a warning), rather than just
+  picking one semi-randomly.
 
 # Improvements
 

--- a/lib/sparql/position_query.rb
+++ b/lib/sparql/position_query.rb
@@ -12,8 +12,12 @@ module WikidataPositionHistory
           WHERE {
             VALUES ?item { wd:%s }
             BIND(EXISTS { wd:%s wdt:P279+ wd:Q4164871  } as ?isPosition)
-            OPTIONAL { ?item p:P571/psv:P571 [ wikibase:timeValue ?inception; wikibase:timePrecision ?inception_precision ] }
-            OPTIONAL { ?item p:P576/psv:P576 [ wikibase:timeValue ?abolition; wikibase:timePrecision ?abolition_precision ] }
+            OPTIONAL { ?item p:P571 [ a wikibase:BestRank ;
+              psv:P571 [ wikibase:timeValue ?inception; wikibase:timePrecision ?inception_precision ]
+            ] }
+            OPTIONAL { ?item p:P576 [ a wikibase:BestRank ;
+              psv:P576 [ wikibase:timeValue ?abolition; wikibase:timePrecision ?abolition_precision ]
+            ] }
             SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
           }
         SPARQL

--- a/lib/sparql/position_query.rb
+++ b/lib/sparql/position_query.rb
@@ -8,7 +8,7 @@ module WikidataPositionHistory
         <<~SPARQL
           # position-metadata
 
-          SELECT DISTINCT ?inception ?inception_precision ?abolition ?abolition_precision ?isPosition
+          SELECT DISTINCT ?item ?inception ?inception_precision ?abolition ?abolition_precision ?isPosition
           WHERE {
             VALUES ?item { wd:%s }
             BIND(EXISTS { wd:%s wdt:P279+ wd:Q4164871  } as ?isPosition)
@@ -29,6 +29,10 @@ module WikidataPositionHistory
   class PositionRow
     def initialize(row)
       @row = row
+    end
+
+    def item
+      QueryService::WikidataItem.new(row.dig(:item, :value))
     end
 
     def inception_date

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -42,8 +42,15 @@ module WikidataPositionHistory
 
   # Data about the position itself, to be passed to the report template
   class Metadata
+    # simplified version of a WikidataPositionHistory::Check
+    Warning = Struct.new(:headline, :explanation)
+
     def initialize(rows)
       @rows = rows
+    end
+
+    def item
+      rows.map(&:item).first
     end
 
     def inception_date
@@ -52,10 +59,25 @@ module WikidataPositionHistory
       inception_dates.join(' / ')
     end
 
+    def inception_warning
+      count = inception_dates.count
+
+      return if count == 1
+      return Warning.new('Missing field', "#{item_qlink} is missing {{P|571}}") if count.zero?
+
+      Warning.new('Multiple values', "#{item_qlink} has more than one {{P|571}}")
+    end
+
     def abolition_date
       return if abolition_dates.empty?
 
       abolition_dates.join(' / ')
+    end
+
+    def abolition_warning
+      return unless abolition_dates.count > 1
+
+      Warning.new('Multiple values', "#{item_qlink} has more than one {{P|576}}")
     end
 
     def position?
@@ -73,6 +95,10 @@ module WikidataPositionHistory
 
     def abolition_dates
       rows.map(&:abolition_date).compact.uniq(&:to_s).sort
+    end
+
+    def item_qlink
+      item.qlink
     end
   end
 

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -25,7 +25,10 @@ module WikidataPositionHistory
         <% if metadata.abolition_date -%>
         |-
         | colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position abolished''': <%= metadata.abolition_date %>
-        | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+        | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
+        <% [metadata.abolition_warning].compact.each do |warning| -%>
+        <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
+        <% end %>
         <% end -%>
         <% table_rows.map(&:values).each do |mandate, bio| -%>
         |-
@@ -40,7 +43,10 @@ module WikidataPositionHistory
         <% if metadata.inception_date -%>
         |-
         | colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position created''': <%= metadata.inception_date %>
-        | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+        | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
+        <% [metadata.inception_warning].compact.each do |warning| -%>
+        <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
+        <% end %>
         <% end -%>
         |}
 

--- a/test/example-data/metadata/Q14211.json
+++ b/test/example-data/metadata/Q14211.json
@@ -1,13 +1,27 @@
 {
   "head" : {
-    "vars" : [ "inception", "abolished" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14211"
+      },
       "inception" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "1721-04-04T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
       }
     } ]
   }

--- a/test/example-data/metadata/Q16147179.json
+++ b/test/example-data/metadata/Q16147179.json
@@ -1,9 +1,13 @@
 {
   "head" : {
-    "vars" : [ "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16147179"
+      },
       "isPosition" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",

--- a/test/example-data/metadata/Q1769526.json
+++ b/test/example-data/metadata/Q1769526.json
@@ -1,13 +1,27 @@
 {
   "head" : {
-    "vars" : [ "inception", "abolished" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1769526"
+      },
       "inception" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "1991-01-01T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "9"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
       }
     } ]
   }

--- a/test/example-data/metadata/Q1837494.json
+++ b/test/example-data/metadata/Q1837494.json
@@ -1,9 +1,13 @@
 {
   "head" : {
-    "vars" : [ "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1837494"
+      },
       "inception" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",

--- a/test/example-data/metadata/Q195965.json
+++ b/test/example-data/metadata/Q195965.json
@@ -1,9 +1,13 @@
 {
   "head" : {
-    "vars" : [ "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q195965"
+      },
       "inception" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",

--- a/test/example-data/metadata/Q20530392.json
+++ b/test/example-data/metadata/Q20530392.json
@@ -1,9 +1,13 @@
 {
   "head" : {
-    "vars" : [ "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20530392"
+      },
       "abolition" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",

--- a/test/example-data/metadata/Q3657870.json
+++ b/test/example-data/metadata/Q3657870.json
@@ -1,9 +1,13 @@
 {
   "head" : {
-    "vars" : [ "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3657870"
+      },
       "abolition" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -30,6 +34,10 @@
         "value" : "true"
       }
     }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3657870"
+      },
       "abolition" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -56,6 +64,10 @@
         "value" : "true"
       }
     }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3657870"
+      },
       "abolition" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -82,6 +94,10 @@
         "value" : "true"
       }
     }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3657870"
+      },
       "abolition" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",

--- a/test/example-data/metadata/Q39055044.json
+++ b/test/example-data/metadata/Q39055044.json
@@ -1,13 +1,27 @@
 {
   "head" : {
-    "vars" : [ "inception", "abolished" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q39055044"
+      },
       "inception" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "2015-05-11T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
       }
     } ]
   }

--- a/test/example-data/metadata/Q4763428.json
+++ b/test/example-data/metadata/Q4763428.json
@@ -1,9 +1,13 @@
 {
   "head" : {
-    "vars" : [ "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4763428"
+      },
       "inception" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",

--- a/test/example-data/metadata/Q56761097.json
+++ b/test/example-data/metadata/Q56761097.json
@@ -1,9 +1,13 @@
 {
   "head" : {
-    "vars" : [ "inception", "inception_precision", "abolition", "abolition_precision" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56761097"
+      },
       "inception" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -13,6 +17,11 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
         "type" : "literal",
         "value" : "9"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
       }
     } ]
   }

--- a/test/example-data/metadata/Q7444267.json
+++ b/test/example-data/metadata/Q7444267.json
@@ -1,9 +1,13 @@
 {
   "head" : {
-    "vars" : [ "inception", "inception_precision", "abolition", "abolition_precision" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7444267"
+      },
       "abolition" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -23,6 +27,11 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
         "type" : "literal",
         "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
       }
     } ]
   }

--- a/test/example-data/metadata/Q756265.json
+++ b/test/example-data/metadata/Q756265.json
@@ -1,13 +1,27 @@
 {
   "head" : {
-    "vars" : [ "inception", "abolished" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q756265"
+      },
       "inception" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
         "value" : "1992-09-03T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
       }
     } ]
   }

--- a/test/example-data/metadata/Q96424184.json
+++ b/test/example-data/metadata/Q96424184.json
@@ -1,9 +1,13 @@
 {
   "head" : {
-    "vars" : [ "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition" ]
   },
   "results" : {
     "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q96424184"
+      },
       "isPosition" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",

--- a/test/expected-output/Q3657870.out
+++ b/test/expected-output/Q3657870.out
@@ -1,0 +1,24 @@
+== {{Q|Q3657870}} officeholders (1957 / 1969 – 1960 / 1972) ==
+{| class="wikitable" style="text-align: center; border: none;"
+|-
+| colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position abolished''': 1960 / 1972
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Multiple values</span>&nbsp;<ref>{{Q|Q3657870}} has more than one {{P|576}}</ref></span>
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q51267}}</span> 1969-10-01 – 1972-01-13
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:The%20National%20Archives%20UK%20-%20CO%201069-50-1.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q8620}}</span> 1957-03-06 – 1960-07-01
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Missing field</span>&nbsp;<ref>{{Q|Q8620}} is missing {{P|1366}}</ref></span>
+|-
+| colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position created''': 1957 / 1969
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Multiple values</span>&nbsp;<ref>{{Q|Q3657870}} has more than one {{P|571}}</ref></span>
+|}
+
+<div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
+  <div style="float:right">[https://query.wikidata.org/#%23%20position-mandates%0A%0ASELECT%20DISTINCT%20%3Fordinal%20%3Fitem%20%3Fstart_date%20%3Fstart_precision%20%3Fend_date%20%3Fend_precision%20%3Fprev%20%3Fnext%20%3Fnature%0AWHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%20wd%3AQ5%20%3B%20p%3AP39%20%3Fposn%20.%0A%20%20%3Fposn%20ps%3AP39%20wd%3AQ3657870%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fposn%20wikibase%3Arank%20wikibase%3ADeprecatedRank%20%7D%0A%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP580%20%5B%20wikibase%3AtimeValue%20%3Fstart_date%3B%20wikibase%3AtimePrecision%20%3Fstart_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP582%20%5B%20wikibase%3AtimeValue%20%3Fend_date%3B%20wikibase%3AtimePrecision%20%3Fend_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1365%7Cpq%3AP155%20%3Fprev%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1366%7Cpq%3AP156%20%3Fnext%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1545%20%3Fordinal%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP5102%20%3Fnature%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fstart_date%29%0A WDQS]</div>
+</div>
+{{reflist}}

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -20,6 +20,9 @@ describe WikidataPositionHistory::Report do
 
     it { expect(metadata.inception_date.to_s).must_equal '1920-08-22' }
     it { expect(metadata.abolition_date.to_s).must_equal '1945' }
+
+    it { expect(metadata.abolition_warning).must_be_nil }
+    it { expect(metadata.inception_warning).must_be_nil }
   end
 
   describe 'office with multiple inception and abolition dates' do
@@ -27,6 +30,9 @@ describe WikidataPositionHistory::Report do
 
     it { expect(metadata.inception_date.to_s).must_equal '1957 / 1969' }
     it { expect(metadata.abolition_date.to_s).must_equal '1960 / 1972' }
+
+    it { expect(metadata.inception_warning.headline).must_equal 'Multiple values' }
+    it { expect(metadata.abolition_warning.headline).must_equal 'Multiple values' }
   end
 
   describe 'office with neither inception nor abolition date' do
@@ -35,6 +41,10 @@ describe WikidataPositionHistory::Report do
     it { expect(metadata.inception_date).must_be_nil }
     it { expect(metadata.abolition_date).must_be_nil }
     it { expect(metadata.position?).must_equal true }
+
+    it { expect(metadata.inception_warning.headline).must_equal 'Missing field' }
+    it { expect(metadata.inception_warning.explanation).must_include '{{Q|Q96424184}}' }
+    it { expect(metadata.abolition_warning).must_be_nil }
   end
 
   describe 'legislative term' do

--- a/test/wikidata_position_history/report/wikitext_spec.rb
+++ b/test/wikidata_position_history/report/wikitext_spec.rb
@@ -41,6 +41,12 @@ describe WikidataPositionHistory::Report do
     it { expect(report.wikitext_with_header).must_equal expected }
   end
 
+  describe 'Prime Minister of Ghana' do
+    let(:id) { 'Q3657870' }
+
+    it { expect(report.wikitext_with_header).must_equal expected }
+  end
+
   describe 'Bishop of Worcester' do
     let(:id) { 'Q1837494' }
 


### PR DESCRIPTION
Warn if a position has multiple values for its inception and/or abolition date.

The framework is also in place to warn if it has no inception date, but we don't currently display that.

Before:
![Screen Shot 2020-09-08 at 09 39 32](https://user-images.githubusercontent.com/57483/92453524-45c3f200-f1b7-11ea-8d20-bbd743e09099.png)

After:
![Screen Shot 2020-09-08 at 11 09 31](https://user-images.githubusercontent.com/57483/92463525-d9032480-f1c3-11ea-87cf-8b15a0e27dec.png)
