### PR TITLE
Show century-precision dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,25 @@
 # Changelog
 
+# Unreleased
+
+## Enhancements
+
+* It seems that the recent ability to handle dates that are only know at
+  decade-level precision isn’t actually enough, as we have some that we
+  only know at century-level precision! (For example, that the position of
+  Lord Chancellor of Ireland was created some time in the 12th Century.
+  Such dates will now appear in a nicer format.
+
 # [1.7.0] 2020-09-08
 
-# Enchancements
+## Enchancements
 
 * Yesterday’s future, when we said we'd do something a little better
   with positions that have multiple inception or abolition dates, has
   arrived. Now we display all of them (with a warning), rather than just
   picking one semi-randomly.
 
-# Improvements
+## Improvements
 
 * A query like https://w.wiki/bVz is taking about 6 seconds to run.
   Changing that to https://w.wiki/bW3 drops that to about half a second.
@@ -39,7 +49,7 @@
 
 * When showing the results for a position from long long ago (such as
   the High Kings of Ireland), display the dates as "862 – 879" not as
-  "862 – 879"
+  "0862 – 0879"
 * If we only know that someone took (or left) office sometime in a given
   decade (i.e. at date precision 8), display that as (say) "1930s"
 

--- a/lib/query_service.rb
+++ b/lib/query_service.rb
@@ -54,7 +54,7 @@ module QueryService
   class WikidataDate
     include Comparable
 
-    DATELEN = { '11' => 10, '10' => 7, '9' => 4, '8' => 4 }.freeze
+    DATELEN = { '11' => 10, '10' => 7, '9' => 4, '8' => 4, '7' => 2 }.freeze
 
     def initialize(str, precision)
       @str = str
@@ -105,6 +105,7 @@ module QueryService
     end
 
     def precisioned_string
+      return "#{truncated_string}. century" if precision == '7'
       return "#{truncated_string}s" if precision == '8'
 
       truncated_string

--- a/test/query_service/wikidata_date_spec.rb
+++ b/test/query_service/wikidata_date_spec.rb
@@ -27,6 +27,12 @@ describe QueryService::WikidataDate do
     it { expect(date.to_s).must_equal '1930s' }
   end
 
+  describe 'precision 07 dates' do
+    let(:date) { QueryService::WikidataDate.new('1200-01-01', '7') }
+
+    it { expect(date.to_s).must_equal '12. century' }
+  end
+
   describe 'pre-1000 precision 11 dates' do
     let(:date) { QueryService::WikidataDate.new('0936-09-25', '11') }
 


### PR DESCRIPTION
Add formatting for dates that are only known at century-level precision:

Before:
![Screen Shot 2020-09-08 at 21 04 41](https://user-images.githubusercontent.com/57483/92522673-05945c00-f217-11ea-876f-8c5b56205447.png)

After:
![Screen Shot 2020-09-08 at 21 05 13](https://user-images.githubusercontent.com/57483/92522665-04632f00-f217-11ea-945f-be1ea152ede1.png)
