### PR TITLE
Warn if officeholders are missing beyond ends of list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Enhancements
 
+* If the very latest person we know of having held this position also
+  has a 'replaced by' qualifier, that’s a sign that the successor should
+  really also have a suitable P39, and actually appear here too. So we
+  want to display a warning in such cases. Likewise if the earliest person
+  we know if also has a 'replaces'
+
 * This report is meant to be used with positions that are held by only a
   single person at a time. Using it to produce a report of everyone who
   has been, say, a Member of the UK Parliament, is the sort of thing that

--- a/lib/wikidata_position_history/checks.rb
+++ b/lib/wikidata_position_history/checks.rb
@@ -25,11 +25,11 @@ module WikidataPositionHistory
       current.prev
     end
 
-    def latest_holder?
+    def later_holder?
       !!later
     end
 
-    def earliest_holder?
+    def earlier_holder?
       !!earlier
     end
   end
@@ -92,7 +92,7 @@ module WikidataPositionHistory
     # Does the 'replaces' match the previous item in the list?
     class WrongPredecessor < Check
       def problem?
-        earliest_holder? && !!predecessor && (earlier.item != predecessor)
+        earlier_holder? && !!predecessor && (earlier.item != predecessor)
       end
 
       def headline
@@ -104,10 +104,25 @@ module WikidataPositionHistory
       end
     end
 
+    # Is there a 'replaces' but no previous item in the list?
+    class MissingPredecessor < Check
+      def problem?
+        predecessor && !earlier_holder?
+      end
+
+      def headline
+        'Inconsistent predecessor'
+      end
+
+      def possible_explanation
+        "#{current.item} has a {{P|1365}} of #{predecessor}, but does not follow anyone here"
+      end
+    end
+
     # Does the 'replaced by' match the next item in the list?
     class WrongSuccessor < Check
       def problem?
-        latest_holder? && !!successor && (later.item != successor)
+        later_holder? && !!successor && (later.item != successor)
       end
 
       def headline
@@ -116,6 +131,21 @@ module WikidataPositionHistory
 
       def possible_explanation
         "#{current.item} has a {{P|1366}} of #{successor}, but is followed by #{later.item} here"
+      end
+    end
+
+    # Is there a 'replaced by' but no next item in the list?
+    class MissingSuccessor < Check
+      def problem?
+        successor && !later_holder?
+      end
+
+      def headline
+        'Inconsistent successor'
+      end
+
+      def possible_explanation
+        "#{current.item} has a {{P|1366}} of #{successor}, but is not followed by anyone here"
       end
     end
 

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -3,7 +3,9 @@
 module WikidataPositionHistory
   # Date for a single mandate row, to be passed to the report template
   class MandateData
-    CHECKS = [Check::MissingFields, Check::WrongPredecessor, Check::WrongSuccessor, Check::Overlap].freeze
+    CHECKS = [Check::MissingFields, Check::Overlap,
+              Check::WrongPredecessor, Check::MissingPredecessor,
+              Check::WrongSuccessor, Check::MissingSuccessor].freeze
 
     def initialize(later, current, earlier)
       @later = later

--- a/test/example-data/biodata/Q54211708.json
+++ b/test/example-data/biodata/Q54211708.json
@@ -1,0 +1,17 @@
+{
+  "head" : {
+    "vars" : [ "item", "image" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1030776"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Yusufhaji.jpg"
+      }
+    } ]
+  }
+}

--- a/test/example-data/mandates/Q54211708.json
+++ b/test/example-data/mandates/Q54211708.json
@@ -1,0 +1,41 @@
+{
+  "head" : {
+    "vars" : [ "ordinal", "item", "start_date", "start_precision", "end_date", "end_precision", "prev", "next", "nature" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1030776"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2008-01-08T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-04-26T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7042423"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12170059"
+      }
+    } ]
+  }
+}

--- a/test/example-data/metadata/Q54211708.json
+++ b/test/example-data/metadata/Q54211708.json
@@ -1,0 +1,23 @@
+{
+  "head" : {
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q54211708"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      }
+    } ]
+  }
+}

--- a/test/wikidata_position_history/checks_spec.rb
+++ b/test/wikidata_position_history/checks_spec.rb
@@ -68,6 +68,20 @@ describe 'Checks' do
     end
   end
 
+  describe 'Minister of Defence of Kenya' do
+    let(:position) { 'Q54211708' }
+
+    it 'warns if latest holder should have a successor' do
+      check = WikidataPositionHistory::Check::MissingSuccessor.new(*mandates.take(3))
+      expect(check.problem?).must_equal true
+    end
+
+    it 'warns if earliest holder should have a predecessor' do
+      check = WikidataPositionHistory::Check::MissingPredecessor.new(*mandates.last(3))
+      expect(check.problem?).must_equal true
+    end
+  end
+
   # Three officeholders, with no qualifiers at all
   describe 'Tanzanian Water Minister' do
     let(:position) { 'Q16147179' }


### PR DESCRIPTION
If the latest officeholder has a 'replaced by', or the earliest
officeholder has a 'replaces', warn that those mandates are msising from
the list.

Before:
![Screen Shot 2020-09-09 at 09 15 17](https://user-images.githubusercontent.com/57483/92572969-08299c80-f27d-11ea-8e16-8be5872443b1.png)

After:
![Screen Shot 2020-09-09 at 09 15 09](https://user-images.githubusercontent.com/57483/92572974-095ac980-f27d-11ea-8c37-ab7437ba8a1d.png)
