### PR TITLE
Add replaces/replaced-by for positions to template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# Unreleased
+
+## Enhancements
+
+* If a position has any successor or predecessor offices (in "replaces"
+  (P1365) or "replaced by" (P1366)) the report will now display those.
+
 # [1.8.0] 2020-09-09
 
 ## Enhancements

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -55,6 +55,18 @@ module WikidataPositionHistory
       rows.map(&:item).first
     end
 
+    def replaces
+      return if replaces_list.empty?
+
+      replaces_list.map(&:qlink).join(', ')
+    end
+
+    def replaced_by
+      return if replaced_by_list.empty?
+
+      replaced_by_list.map(&:qlink).join(', ')
+    end
+
     def inception_date
       return if inception_dates.empty?
 
@@ -95,6 +107,14 @@ module WikidataPositionHistory
     private
 
     attr_reader :rows
+
+    def replaces_list
+      rows.map(&:replaces).compact.uniq(&:id).sort_by(&:id)
+    end
+
+    def replaced_by_list
+      rows.map(&:replaced_by).compact.uniq(&:id).sort_by(&:id)
+    end
 
     def inception_dates
       rows.map(&:inception_date).compact.uniq(&:to_s).sort

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -24,11 +24,23 @@ module WikidataPositionHistory
         {| class="wikitable" style="text-align: center; border: none;"
         <% if metadata.abolition_date -%>
         |-
-        | colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position abolished''': <%= metadata.abolition_date %>
-        | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
+        | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position abolished''':
+        | style="border: none; background: #fff; text-align: left;" | <%= metadata.abolition_date %>
+        | style="border: none; background: #fff; text-align: left;" | \
         <% [metadata.abolition_warning].compact.each do |warning| -%>
         <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
         <% end %>
+        <% end -%>
+        <% if metadata.replaced_by -%>
+        |-
+        | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaced by''':
+        | style=" border: none; background: #fff; text-align: left;" | <%= metadata.replaced_by %>
+        | style=" border: none; background: #fff; text-align: left;" |
+        <% end -%>
+        <% if metadata.replaced_by || metadata.abolition_date -%>
+        |-
+        | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+        | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
         <% end -%>
         <% table_rows.map(&:values).each do |mandate, bio| -%>
         |-
@@ -40,13 +52,25 @@ module WikidataPositionHistory
         <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
         <% end %>
         <% end -%>
+        <% if metadata.replaced_by || metadata.abolition_date -%>
+        |-
+        | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+        | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+        <% end -%>
         <% if metadata.inception_date -%>
         |-
-        | colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position created''': <%= metadata.inception_date %>
+        | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
+        | style="border: none; background: #fff; text-align: left;" | <%= metadata.inception_date %>
         | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
         <% [metadata.inception_warning].compact.each do |warning| -%>
         <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
         <% end %>
+        <% end -%>
+        <% if metadata.replaces -%>
+        |-
+        | colspan="2" style=" border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaces''':
+        | style="border: none; background: #fff; text-align: left;" | <%= metadata.replaces %>
+        | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" |
         <% end -%>
         |}
 

--- a/test/example-data/metadata/Q13653224.json
+++ b/test/example-data/metadata/Q13653224.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q14211.json
+++ b/test/example-data/metadata/Q14211.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q16147179.json
+++ b/test/example-data/metadata/Q16147179.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q1769526.json
+++ b/test/example-data/metadata/Q1769526.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q1837494.json
+++ b/test/example-data/metadata/Q1837494.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q195965.json
+++ b/test/example-data/metadata/Q195965.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q20530392.json
+++ b/test/example-data/metadata/Q20530392.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {
@@ -37,6 +37,14 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q967549"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q61975993"
       }
     } ]
   }

--- a/test/example-data/metadata/Q3657870.json
+++ b/test/example-data/metadata/Q3657870.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q38780172.json
+++ b/test/example-data/metadata/Q38780172.json
@@ -1,0 +1,51 @@
+{
+  "head" : {
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q38780172"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1981-09-12T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1973-06-01T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q38780315"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q862638"
+      }
+    } ]
+  }
+}

--- a/test/example-data/metadata/Q39055044.json
+++ b/test/example-data/metadata/Q39055044.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q4763428.json
+++ b/test/example-data/metadata/Q4763428.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q54211708.json
+++ b/test/example-data/metadata/Q54211708.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q56761097.json
+++ b/test/example-data/metadata/Q56761097.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q67202316.json
+++ b/test/example-data/metadata/Q67202316.json
@@ -1,0 +1,180 @@
+{
+  "head" : {
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      }
+    } ]
+  }
+}

--- a/test/example-data/metadata/Q7444267.json
+++ b/test/example-data/metadata/Q7444267.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q756265.json
+++ b/test/example-data/metadata/Q756265.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q96424184.json
+++ b/test/example-data/metadata/Q96424184.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/expected-output/Q14211.out
+++ b/test/expected-output/Q14211.out
@@ -371,7 +371,8 @@
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q104190}}</span> 1721-04-15 – 1742-02-27
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Date overlap</span>&nbsp;<ref>{{Q|Q104190}} has a {{P|582}} of 1742-02-27, which is later than the {{P|580}} of 1742-02-16 for {{Q|Q270415}}</ref></span>
 |-
-| colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position created''': 1721-04-04
+| colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
+| style="border: none; background: #fff; text-align: left;" | 1721-04-04
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |}
 

--- a/test/expected-output/Q1837494.out
+++ b/test/expected-output/Q1837494.out
@@ -596,7 +596,8 @@
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q8077364}}</span> 
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Missing fields</span>&nbsp;<ref>{{Q|Q8077364}} is missing {{P|580}}, {{P|582}}, {{P|1366}}</ref></span>
 |-
-| colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position created''': 680
+| colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
+| style="border: none; background: #fff; text-align: left;" | 680
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |}
 

--- a/test/expected-output/Q3657870.out
+++ b/test/expected-output/Q3657870.out
@@ -1,8 +1,12 @@
 == {{Q|Q3657870}} officeholders (1957 / 1969 – 1960 / 1972) ==
 {| class="wikitable" style="text-align: center; border: none;"
 |-
-| colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position abolished''': 1960 / 1972
-| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Multiple values</span>&nbsp;<ref>{{Q|Q3657870}} has more than one {{P|576}}</ref></span>
+| colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position abolished''':
+| style="border: none; background: #fff; text-align: left;" | 1960 / 1972
+| style="border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Multiple values</span>&nbsp;<ref>{{Q|Q3657870}} has more than one {{P|576}}</ref></span>
+|-
+| colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+| colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | 
@@ -14,7 +18,11 @@
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q8620}}</span> 1957-03-06 – 1960-07-01
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Missing field</span>&nbsp;<ref>{{Q|Q8620}} is missing {{P|1366}}</ref></span>
 |-
-| colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position created''': 1957 / 1969
+| colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+| colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+|-
+| colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
+| style="border: none; background: #fff; text-align: left;" | 1957 / 1969
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Multiple values</span>&nbsp;<ref>{{Q|Q3657870}} has more than one {{P|571}}</ref></span>
 |}
 

--- a/test/expected-output/Q56761097.out
+++ b/test/expected-output/Q56761097.out
@@ -71,7 +71,8 @@
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q15995878}}</span> 1922 – 1926
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
-| colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position created''': 1922
+| colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
+| style="border: none; background: #fff; text-align: left;" | 1922
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |}
 

--- a/test/expected-output/Q7444267.out
+++ b/test/expected-output/Q7444267.out
@@ -1,8 +1,12 @@
 == {{Q|Q7444267}} officeholders (1920-08-22 – 1945) ==
 {| class="wikitable" style="text-align: center; border: none;"
 |-
-| colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position abolished''': 1945
-| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+| colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position abolished''':
+| style="border: none; background: #fff; text-align: left;" | 1945
+| style="border: none; background: #fff; text-align: left;" | 
+|-
+| colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+| colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | [[File:David%20Grenfell.jpg|75px]]
@@ -64,7 +68,11 @@
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q5586304}}</span> 1920-08-22 – 1922-11-06
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
-| colspan="3" style="padding:0.5em 2em; border: none; background: #fff; font-size: 1.25em; text-align: right;" | '''Position created''': 1920-08-22
+| colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+| colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+|-
+| colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
+| style="border: none; background: #fff; text-align: left;" | 1920-08-22
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |}
 

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -57,6 +57,13 @@ describe WikidataPositionHistory::Report do
     it { expect(metadata.replaced_by).must_equal '{{Q|Q862638}}' }
   end
 
+  describe 'office with mutiples replaces and replaced by' do
+    let(:position_id) { 'Q67202316' }
+
+    it { expect(metadata.replaces).must_equal '{{Q|Q67202278}}, {{Q|Q67202332}}' }
+    it { expect(metadata.replaced_by).must_equal '{{Q|Q50390723}}, {{Q|Q51280630}}' }
+  end
+
   describe 'legislative term' do
     let(:position_id) { 'Q20530392' }
 

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -6,7 +6,7 @@ describe WikidataPositionHistory::Report do
   before { use_sample_data }
 
   let(:report) { WikidataPositionHistory::Report.new(position_id) }
-  let(:metadata) { report.template_params[:metadata] }
+  let(:metadata) { report.send(:metadata) }
 
   describe 'office with inception but no abolition date' do
     let(:position_id) { 'Q14211' }
@@ -45,6 +45,16 @@ describe WikidataPositionHistory::Report do
     it { expect(metadata.inception_warning.headline).must_equal 'Missing field' }
     it { expect(metadata.inception_warning.explanation).must_include '{{Q|Q96424184}}' }
     it { expect(metadata.abolition_warning).must_be_nil }
+
+    it { expect(metadata.replaces).must_be_nil }
+    it { expect(metadata.replaced_by).must_be_nil }
+  end
+
+  describe 'office with replaces and replaced by' do
+    let(:position_id) { 'Q38780172' }
+
+    it { expect(metadata.replaces).must_equal '{{Q|Q38780315}}' }
+    it { expect(metadata.replaced_by).must_equal '{{Q|Q862638}}' }
   end
 
   describe 'legislative term' do


### PR DESCRIPTION
Where we know a successor or predecessor position, add those to the output.

Before:
![Screen Shot 2020-09-11 at 10 50 59](https://user-images.githubusercontent.com/57483/92906979-d2231e80-f41c-11ea-8448-8c27c4269ae9.png)

After:
![Screen Shot 2020-09-11 at 10 51 31](https://user-images.githubusercontent.com/57483/92906970-d0595b00-f41c-11ea-822f-a566023c356c.png)

with multiple:

![Screen Shot 2020-09-11 at 10 54 56](https://user-images.githubusercontent.com/57483/92907497-48c01c00-f41d-11ea-95d1-5b1519c72dfa.png)


