### PR TITLE
[refactoring] create OutputRow namespace

### DIFF
--- a/lib/wikidata_position_history.rb
+++ b/lib/wikidata_position_history.rb
@@ -7,6 +7,7 @@ require 'sparql/bio_query'
 require 'sparql/mandates_query'
 require 'wikidata_position_history/checks'
 require 'wikidata_position_history/template'
+require 'wikidata_position_history/output_row'
 require 'wikidata_position_history/report'
 require 'wikidata_position_history/version'
 

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module WikidataPositionHistory
+  class OutputRow
+    # Date for a single mandate row, to be passed to the report template
+    class Mandate
+      CHECKS = [Check::MissingFields, Check::Overlap,
+                Check::WrongPredecessor, Check::MissingPredecessor,
+                Check::WrongSuccessor, Check::MissingSuccessor].freeze
+
+      def initialize(later, current, earlier)
+        @later = later
+        @current = current
+        @earlier = earlier
+      end
+
+      def ordinal_string
+        ordinal = current.ordinal or return ''
+        "#{ordinal}."
+      end
+
+      def person
+        current.item
+      end
+
+      def dates
+        dates = [current.start_date, current.end_date]
+        return '' if dates.compact.empty?
+
+        dates.join(' – ')
+      end
+
+      def acting?
+        current.acting?
+      end
+
+      def warnings
+        CHECKS.map { |klass| klass.new(later, current, earlier) }.select(&:problem?)
+      end
+
+      private
+
+      attr_reader :later, :current, :earlier
+    end
+  end
+end

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -99,5 +99,31 @@ module WikidataPositionHistory
         metadata.abolition_dates
       end
     end
+
+    # Data for the the position that comes after this one
+    class Successor
+      def initialize(metadata)
+        @metadata = metadata
+      end
+
+      def position
+        return if position_list.empty?
+
+        position_list.map(&:qlink).join(', ')
+      end
+
+      # TODO: add some checks
+      def warnings
+        []
+      end
+
+      private
+
+      attr_reader :metadata
+
+      def position_list
+        metadata.replaced_by_list
+      end
+    end
   end
 end

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -76,5 +76,36 @@ module WikidataPositionHistory
         metadata.inception_dates
       end
     end
+
+    # Data for the Abolition date of the position
+    class Abolition
+      # simplified version of a WikidataPositionHistory::Check
+      Warning = Struct.new(:headline, :explanation)
+
+      def initialize(metadata)
+        @metadata = metadata
+      end
+
+      def date
+        return if dates.empty?
+
+        dates.join(' / ')
+      end
+
+      def warnings
+        return [] unless dates.count > 1
+
+        qlink = metadata.item_qlink
+        [Warning.new('Multiple values', "#{qlink} has more than one {{P|576}}")]
+      end
+
+      private
+
+      attr_reader :metadata
+
+      def dates
+        metadata.abolition_dates
+      end
+    end
   end
 end

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -42,5 +42,39 @@ module WikidataPositionHistory
 
       attr_reader :later, :current, :earlier
     end
+
+    # Data for the Inception date of the position
+    class Inception
+      # simplified version of a WikidataPositionHistory::Check
+      Warning = Struct.new(:headline, :explanation)
+
+      def initialize(metadata)
+        @metadata = metadata
+      end
+
+      def date
+        return if dates.empty?
+
+        dates.join(' / ')
+      end
+
+      def warnings
+        count = dates.count
+        return [] if count == 1
+
+        qlink = metadata.item_qlink
+        return [Warning.new('Missing field', "#{qlink} is missing {{P|571}}")] if count.zero?
+
+        [Warning.new('Multiple values', "#{qlink} has more than one {{P|571}}")]
+      end
+
+      private
+
+      attr_reader :metadata
+
+      def dates
+        metadata.inception_dates
+      end
+    end
   end
 end

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -63,7 +63,7 @@ module WikidataPositionHistory
       attr_reader :metadata
 
       def qlink
-        metadata.item_qlink
+        metadata.position.qlink
       end
     end
 

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -125,5 +125,31 @@ module WikidataPositionHistory
         metadata.replaced_by_list
       end
     end
+
+    # Data for the the position that came before this one
+    class Predecessor
+      def initialize(metadata)
+        @metadata = metadata
+      end
+
+      def position
+        return if position_list.empty?
+
+        position_list.map(&:qlink).join(', ')
+      end
+
+      # TODO: add some checks
+      def warnings
+        []
+      end
+
+      private
+
+      attr_reader :metadata
+
+      def position_list
+        metadata.replaces_list
+      end
+    end
   end
 end

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -43,8 +43,8 @@ module WikidataPositionHistory
       attr_reader :later, :current, :earlier
     end
 
-    # Data for the Inception date of the position
-    class Inception
+    # Base class for the Inception/Abolition date rows
+    class PositionDate
       # simplified version of a WikidataPositionHistory::Check
       Warning = Struct.new(:headline, :explanation)
 
@@ -58,11 +58,21 @@ module WikidataPositionHistory
         dates.join(' / ')
       end
 
+      private
+
+      attr_reader :metadata
+
+      def qlink
+        metadata.item_qlink
+      end
+    end
+
+    # Data for the Inception date of the position
+    class Inception < PositionDate
       def warnings
         count = dates.count
         return [] if count == 1
 
-        qlink = metadata.item_qlink
         return [Warning.new('Missing field', "#{qlink} is missing {{P|571}}")] if count.zero?
 
         [Warning.new('Multiple values', "#{qlink} has more than one {{P|571}}")]
@@ -70,38 +80,20 @@ module WikidataPositionHistory
 
       private
 
-      attr_reader :metadata
-
       def dates
         metadata.inception_dates
       end
     end
 
     # Data for the Abolition date of the position
-    class Abolition
-      # simplified version of a WikidataPositionHistory::Check
-      Warning = Struct.new(:headline, :explanation)
-
-      def initialize(metadata)
-        @metadata = metadata
-      end
-
-      def date
-        return if dates.empty?
-
-        dates.join(' / ')
-      end
-
+    class Abolition < PositionDate
       def warnings
         return [] unless dates.count > 1
 
-        qlink = metadata.item_qlink
         [Warning.new('Multiple values', "#{qlink} has more than one {{P|576}}")]
       end
 
       private
-
-      attr_reader :metadata
 
       def dates
         metadata.abolition_dates

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -100,8 +100,8 @@ module WikidataPositionHistory
       end
     end
 
-    # Data for the the position that comes after this one
-    class Successor
+    # Data for related position: e.g. Successor/Predecessor
+    class RelatedPosition
       def initialize(metadata)
         @metadata = metadata
       end
@@ -120,33 +120,17 @@ module WikidataPositionHistory
       private
 
       attr_reader :metadata
+    end
 
+    # Data for the position that comes after this one
+    class Successor < RelatedPosition
       def position_list
         metadata.replaced_by_list
       end
     end
 
-    # Data for the the position that came before this one
-    class Predecessor
-      def initialize(metadata)
-        @metadata = metadata
-      end
-
-      def position
-        return if position_list.empty?
-
-        position_list.map(&:qlink).join(', ')
-      end
-
-      # TODO: add some checks
-      def warnings
-        []
-      end
-
-      private
-
-      attr_reader :metadata
-
+    # Data for the position that came before this one
+    class Predecessor < RelatedPosition
       def position_list
         metadata.replaces_list
       end

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -20,10 +20,8 @@ module WikidataPositionHistory
       replaces_list.map(&:qlink).join(', ')
     end
 
-    def replaced_by
-      return if replaced_by_list.empty?
-
-      replaced_by_list.map(&:qlink).join(', ')
+    def successor
+      @successor ||= OutputRow::Successor.new(self)
     end
 
     def inception

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -30,16 +30,8 @@ module WikidataPositionHistory
       @inception ||= OutputRow::Inception.new(self)
     end
 
-    def abolition_date
-      return if abolition_dates.empty?
-
-      abolition_dates.join(' / ')
-    end
-
-    def abolition_warning
-      return unless abolition_dates.count > 1
-
-      Warning.new('Multiple values', "#{item_qlink} has more than one {{P|576}}")
+    def abolition
+      @abolition ||= OutputRow::Abolition.new(self)
     end
 
     def position?
@@ -98,7 +90,7 @@ module WikidataPositionHistory
     end
 
     def position_dates
-      dates = [metadata.inception.date, metadata.abolition_date]
+      dates = [metadata.inception.date, metadata.abolition.date]
       return '' if dates.compact.empty?
 
       format('(%s)', dates.join(' – '))

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -26,19 +26,8 @@ module WikidataPositionHistory
       replaced_by_list.map(&:qlink).join(', ')
     end
 
-    def inception_date
-      return if inception_dates.empty?
-
-      inception_dates.join(' / ')
-    end
-
-    def inception_warning
-      count = inception_dates.count
-
-      return if count == 1
-      return Warning.new('Missing field', "#{item_qlink} is missing {{P|571}}") if count.zero?
-
-      Warning.new('Multiple values', "#{item_qlink} has more than one {{P|571}}")
+    def inception
+      @inception ||= OutputRow::Inception.new(self)
     end
 
     def abolition_date
@@ -63,10 +52,6 @@ module WikidataPositionHistory
       rows.map(&:legislator?).first
     end
 
-    private
-
-    attr_reader :rows
-
     def replaces_list
       rows.map(&:replaces).compact.uniq(&:id).sort_by(&:id)
     end
@@ -86,6 +71,10 @@ module WikidataPositionHistory
     def item_qlink
       item.qlink
     end
+
+    private
+
+    attr_reader :rows
   end
 
   # The entire wikitext generated for this report
@@ -109,7 +98,7 @@ module WikidataPositionHistory
     end
 
     def position_dates
-      dates = [metadata.inception_date, metadata.abolition_date]
+      dates = [metadata.inception.date, metadata.abolition_date]
       return '' if dates.compact.empty?
 
       format('(%s)', dates.join(' – '))

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -3,14 +3,11 @@
 module WikidataPositionHistory
   # Data about the position itself, to be passed to the report template
   class Metadata
-    # simplified version of a WikidataPositionHistory::Check
-    Warning = Struct.new(:headline, :explanation)
-
     def initialize(rows)
       @rows = rows
     end
 
-    def item
+    def position
       rows.map(&:item).first
     end
 
@@ -54,10 +51,6 @@ module WikidataPositionHistory
 
     def abolition_dates
       rows.map(&:abolition_date).compact.uniq(&:to_s).sort
-    end
-
-    def item_qlink
-      item.qlink
     end
 
     private

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -14,10 +14,8 @@ module WikidataPositionHistory
       rows.map(&:item).first
     end
 
-    def replaces
-      return if replaces_list.empty?
-
-      replaces_list.map(&:qlink).join(', ')
+    def predecessor
+      @predecessor ||= OutputRow::Predecessor.new(self)
     end
 
     def successor

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -1,47 +1,6 @@
 # frozen_string_literal: true
 
 module WikidataPositionHistory
-  # Date for a single mandate row, to be passed to the report template
-  class MandateData
-    CHECKS = [Check::MissingFields, Check::Overlap,
-              Check::WrongPredecessor, Check::MissingPredecessor,
-              Check::WrongSuccessor, Check::MissingSuccessor].freeze
-
-    def initialize(later, current, earlier)
-      @later = later
-      @current = current
-      @earlier = earlier
-    end
-
-    def ordinal_string
-      ordinal = current.ordinal or return ''
-      "#{ordinal}."
-    end
-
-    def person
-      current.item
-    end
-
-    def dates
-      dates = [current.start_date, current.end_date]
-      return '' if dates.compact.empty?
-
-      dates.join(' – ')
-    end
-
-    def acting?
-      current.acting?
-    end
-
-    def warnings
-      CHECKS.map { |klass| klass.new(later, current, earlier) }.select(&:problem?)
-    end
-
-    private
-
-    attr_reader :later, :current, :earlier
-  end
-
   # Data about the position itself, to be passed to the report template
   class Metadata
     # simplified version of a WikidataPositionHistory::Check
@@ -205,7 +164,7 @@ module WikidataPositionHistory
     def table_rows
       padded_mandates.each_cons(3).map do |later, current, earlier|
         {
-          mandate: MandateData.new(later, current, earlier),
+          mandate: OutputRow::Mandate.new(later, current, earlier),
           bio:     biodata_for(current.officeholder),
         }
       end

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -66,10 +66,10 @@ module WikidataPositionHistory
         <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
         <% end %>
         <% end -%>
-        <% if metadata.replaces -%>
+        <% if metadata.predecessor.position -%>
         |-
         | colspan="2" style=" border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaces''':
-        | style="border: none; background: #fff; text-align: left;" | <%= metadata.replaces %>
+        | style="border: none; background: #fff; text-align: left;" | <%= metadata.predecessor.position %>
         | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" |
         <% end -%>
         |}

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -57,12 +57,12 @@ module WikidataPositionHistory
         | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
         | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
         <% end -%>
-        <% if metadata.inception_date -%>
+        <% if metadata.inception.date -%>
         |-
         | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
-        | style="border: none; background: #fff; text-align: left;" | <%= metadata.inception_date %>
+        | style="border: none; background: #fff; text-align: left;" | <%= metadata.inception.date %>
         | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
-        <% [metadata.inception_warning].compact.each do |warning| -%>
+        <% metadata.inception.warnings.each do |warning| -%>
         <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
         <% end %>
         <% end -%>

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -31,13 +31,13 @@ module WikidataPositionHistory
         <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
         <% end %>
         <% end -%>
-        <% if metadata.replaced_by -%>
+        <% if metadata.successor.position -%>
         |-
         | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaced by''':
-        | style=" border: none; background: #fff; text-align: left;" | <%= metadata.replaced_by %>
+        | style=" border: none; background: #fff; text-align: left;" | <%= metadata.successor.position %>
         | style=" border: none; background: #fff; text-align: left;" |
         <% end -%>
-        <% if metadata.replaced_by || metadata.abolition.date -%>
+        <% if metadata.successor.position || metadata.abolition.date -%>
         |-
         | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
         | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
@@ -52,7 +52,7 @@ module WikidataPositionHistory
         <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
         <% end %>
         <% end -%>
-        <% if metadata.replaced_by || metadata.abolition.date -%>
+        <% if metadata.successor.position || metadata.abolition.date -%>
         |-
         | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
         | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -22,12 +22,12 @@ module WikidataPositionHistory
     def template_text
       <<~ERB
         {| class="wikitable" style="text-align: center; border: none;"
-        <% if metadata.abolition_date -%>
+        <% if metadata.abolition.date -%>
         |-
         | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position abolished''':
-        | style="border: none; background: #fff; text-align: left;" | <%= metadata.abolition_date %>
+        | style="border: none; background: #fff; text-align: left;" | <%= metadata.abolition.date %>
         | style="border: none; background: #fff; text-align: left;" | \
-        <% [metadata.abolition_warning].compact.each do |warning| -%>
+        <% metadata.abolition.warnings.each do |warning| -%>
         <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
         <% end %>
         <% end -%>
@@ -37,7 +37,7 @@ module WikidataPositionHistory
         | style=" border: none; background: #fff; text-align: left;" | <%= metadata.replaced_by %>
         | style=" border: none; background: #fff; text-align: left;" |
         <% end -%>
-        <% if metadata.replaced_by || metadata.abolition_date -%>
+        <% if metadata.replaced_by || metadata.abolition.date -%>
         |-
         | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
         | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
@@ -52,7 +52,7 @@ module WikidataPositionHistory
         <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
         <% end %>
         <% end -%>
-        <% if metadata.replaced_by || metadata.abolition_date -%>
+        <% if metadata.replaced_by || metadata.abolition.date -%>
         |-
         | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
         | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -46,21 +46,21 @@ describe WikidataPositionHistory::Report do
     it { expect(metadata.inception.warnings.first.explanation).must_include '{{Q|Q96424184}}' }
     it { expect(metadata.abolition.warnings.first).must_be_nil }
 
-    it { expect(metadata.replaces).must_be_nil }
+    it { expect(metadata.predecessor.position).must_be_nil }
     it { expect(metadata.successor.position).must_be_nil }
   end
 
   describe 'office with replaces and replaced by' do
     let(:position_id) { 'Q38780172' }
 
-    it { expect(metadata.replaces).must_equal '{{Q|Q38780315}}' }
+    it { expect(metadata.predecessor.position).must_equal '{{Q|Q38780315}}' }
     it { expect(metadata.successor.position).must_equal '{{Q|Q862638}}' }
   end
 
   describe 'office with mutiples replaces and replaced by' do
     let(:position_id) { 'Q67202316' }
 
-    it { expect(metadata.replaces).must_equal '{{Q|Q67202278}}, {{Q|Q67202332}}' }
+    it { expect(metadata.predecessor.position).must_equal '{{Q|Q67202278}}, {{Q|Q67202332}}' }
     it { expect(metadata.successor.position).must_equal '{{Q|Q50390723}}, {{Q|Q51280630}}' }
   end
 

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -47,21 +47,21 @@ describe WikidataPositionHistory::Report do
     it { expect(metadata.abolition.warnings.first).must_be_nil }
 
     it { expect(metadata.replaces).must_be_nil }
-    it { expect(metadata.replaced_by).must_be_nil }
+    it { expect(metadata.successor.position).must_be_nil }
   end
 
   describe 'office with replaces and replaced by' do
     let(:position_id) { 'Q38780172' }
 
     it { expect(metadata.replaces).must_equal '{{Q|Q38780315}}' }
-    it { expect(metadata.replaced_by).must_equal '{{Q|Q862638}}' }
+    it { expect(metadata.successor.position).must_equal '{{Q|Q862638}}' }
   end
 
   describe 'office with mutiples replaces and replaced by' do
     let(:position_id) { 'Q67202316' }
 
     it { expect(metadata.replaces).must_equal '{{Q|Q67202278}}, {{Q|Q67202332}}' }
-    it { expect(metadata.replaced_by).must_equal '{{Q|Q50390723}}, {{Q|Q51280630}}' }
+    it { expect(metadata.successor.position).must_equal '{{Q|Q50390723}}, {{Q|Q51280630}}' }
   end
 
   describe 'legislative term' do

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -11,39 +11,39 @@ describe WikidataPositionHistory::Report do
   describe 'office with inception but no abolition date' do
     let(:position_id) { 'Q14211' }
 
-    it { expect(metadata.inception_date.to_s).must_equal '1721-04-04' }
+    it { expect(metadata.inception.date.to_s).must_equal '1721-04-04' }
     it { expect(metadata.abolition_date).must_be_nil }
   end
 
   describe 'office with both inception and abolition date' do
     let(:position_id) { 'Q7444267' }
 
-    it { expect(metadata.inception_date.to_s).must_equal '1920-08-22' }
+    it { expect(metadata.inception.date.to_s).must_equal '1920-08-22' }
     it { expect(metadata.abolition_date.to_s).must_equal '1945' }
 
     it { expect(metadata.abolition_warning).must_be_nil }
-    it { expect(metadata.inception_warning).must_be_nil }
+    it { expect(metadata.inception.warnings).must_be_empty }
   end
 
   describe 'office with multiple inception and abolition dates' do
     let(:position_id) { 'Q3657870' }
 
-    it { expect(metadata.inception_date.to_s).must_equal '1957 / 1969' }
+    it { expect(metadata.inception.date.to_s).must_equal '1957 / 1969' }
     it { expect(metadata.abolition_date.to_s).must_equal '1960 / 1972' }
 
-    it { expect(metadata.inception_warning.headline).must_equal 'Multiple values' }
+    it { expect(metadata.inception.warnings.first.headline).must_equal 'Multiple values' }
     it { expect(metadata.abolition_warning.headline).must_equal 'Multiple values' }
   end
 
   describe 'office with neither inception nor abolition date' do
     let(:position_id) { 'Q96424184' }
 
-    it { expect(metadata.inception_date).must_be_nil }
+    it { expect(metadata.inception.date).must_be_nil }
     it { expect(metadata.abolition_date).must_be_nil }
     it { expect(metadata.position?).must_equal true }
 
-    it { expect(metadata.inception_warning.headline).must_equal 'Missing field' }
-    it { expect(metadata.inception_warning.explanation).must_include '{{Q|Q96424184}}' }
+    it { expect(metadata.inception.warnings.first.headline).must_equal 'Missing field' }
+    it { expect(metadata.inception.warnings.first.explanation).must_include '{{Q|Q96424184}}' }
     it { expect(metadata.abolition_warning).must_be_nil }
 
     it { expect(metadata.replaces).must_be_nil }

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -12,16 +12,16 @@ describe WikidataPositionHistory::Report do
     let(:position_id) { 'Q14211' }
 
     it { expect(metadata.inception.date.to_s).must_equal '1721-04-04' }
-    it { expect(metadata.abolition_date).must_be_nil }
+    it { expect(metadata.abolition.date).must_be_nil }
   end
 
   describe 'office with both inception and abolition date' do
     let(:position_id) { 'Q7444267' }
 
     it { expect(metadata.inception.date.to_s).must_equal '1920-08-22' }
-    it { expect(metadata.abolition_date.to_s).must_equal '1945' }
+    it { expect(metadata.abolition.date.to_s).must_equal '1945' }
 
-    it { expect(metadata.abolition_warning).must_be_nil }
+    it { expect(metadata.abolition.warnings.first).must_be_nil }
     it { expect(metadata.inception.warnings).must_be_empty }
   end
 
@@ -29,22 +29,22 @@ describe WikidataPositionHistory::Report do
     let(:position_id) { 'Q3657870' }
 
     it { expect(metadata.inception.date.to_s).must_equal '1957 / 1969' }
-    it { expect(metadata.abolition_date.to_s).must_equal '1960 / 1972' }
+    it { expect(metadata.abolition.date.to_s).must_equal '1960 / 1972' }
 
     it { expect(metadata.inception.warnings.first.headline).must_equal 'Multiple values' }
-    it { expect(metadata.abolition_warning.headline).must_equal 'Multiple values' }
+    it { expect(metadata.abolition.warnings.first.headline).must_equal 'Multiple values' }
   end
 
   describe 'office with neither inception nor abolition date' do
     let(:position_id) { 'Q96424184' }
 
     it { expect(metadata.inception.date).must_be_nil }
-    it { expect(metadata.abolition_date).must_be_nil }
+    it { expect(metadata.abolition.date).must_be_nil }
     it { expect(metadata.position?).must_equal true }
 
     it { expect(metadata.inception.warnings.first.headline).must_equal 'Missing field' }
     it { expect(metadata.inception.warnings.first.explanation).must_include '{{Q|Q96424184}}' }
-    it { expect(metadata.abolition_warning).must_be_nil }
+    it { expect(metadata.abolition.warnings.first).must_be_nil }
 
     it { expect(metadata.replaces).must_be_nil }
     it { expect(metadata.replaced_by).must_be_nil }


### PR DESCRIPTION
Move most of the output into OutputRow objects, so that the template can be a little more consistent in how it iterates over these.