### PR TITLE
Add implied successor/predecessor positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+# Unreleased
+
+## Enhancements
+
+* If some other position has a "replaces" (P1365) or "replaced by"
+  (P1366) pointing to _this_ position, but this position doesn't have
+  the reciprocal inverse claims back to that one, include them as a
+  successor/predecessor, but warn that it’s only an indirect connection.
+
+* The warnings in the above case now use an on-wiki template for their
+  text. This means they can be translated into other languages, and also
+  means that backlinks to these templates, via WhatLinksHere, can act as
+  a TODO list. The other warnings will be migrated to this approach Real
+  Soon Now™.
+
 # [1.9.0] 2020-09-11
 
 ## Enhancements

--- a/lib/query_service.rb
+++ b/lib/query_service.rb
@@ -37,12 +37,20 @@ module QueryService
       @url = url
     end
 
+    def eql?(other)
+      id == other.id
+    end
+
     def id
       url.split('/').last unless url.to_s.empty?
     end
 
     def qlink
       "{{Q|#{id}}}" if id
+    end
+
+    def qlink_i
+      "''{{Q|#{id}}}''" if id
     end
 
     private

--- a/lib/sparql/position_query.rb
+++ b/lib/sparql/position_query.rb
@@ -9,7 +9,7 @@ module WikidataPositionHistory
           # position-metadata
 
           SELECT DISTINCT ?item ?inception ?inception_precision ?abolition ?abolition_precision
-                          ?replaces ?replacedBy
+                          ?replaces ?replacedBy ?derivedReplaces ?derivedReplacedBy
                           ?isPosition ?isLegislator
           WHERE {
             VALUES ?item { wd:%s }
@@ -23,6 +23,8 @@ module WikidataPositionHistory
             ] }
             OPTIONAL { ?item wdt:P1365 ?replaces }
             OPTIONAL { ?item wdt:P1366 ?replacedBy }
+            OPTIONAL { ?derivedReplaces wdt:P1366 ?item }
+            OPTIONAL { ?derivedReplacedBy wdt:P1365 ?item }
           }
         SPARQL
       end
@@ -53,6 +55,14 @@ module WikidataPositionHistory
 
     def replaced_by
       item_from(:replacedBy)
+    end
+
+    def derived_replaces
+      item_from(:derivedReplaces)
+    end
+
+    def derived_replaced_by
+      item_from(:derivedReplacedBy)
     end
 
     def position?

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -107,9 +107,9 @@ module WikidataPositionHistory
       end
 
       def position
-        return if position_list.empty?
+        return if implied_list.empty?
 
-        position_list.map(&:qlink).join(', ')
+        (implied_list.direct.map(&:qlink) + implied_list.indirect_only.map(&:qlink_i)).join(', ')
       end
 
       # TODO: add some checks
@@ -124,15 +124,15 @@ module WikidataPositionHistory
 
     # Data for the position that comes after this one
     class Successor < RelatedPosition
-      def position_list
-        metadata.replaced_by_list
+      def implied_list
+        metadata.replaced_by_combined
       end
     end
 
     # Data for the position that came before this one
     class Predecessor < RelatedPosition
-      def position_list
-        metadata.replaces_list
+      def implied_list
+        metadata.replaces_combined
       end
     end
   end

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module WikidataPositionHistory
+  # simplified version of a WikidataPositionHistory::Check
+  Warning = Struct.new(:headline, :explanation)
+
   class OutputRow
     # Date for a single mandate row, to be passed to the report template
     class Mandate
@@ -45,9 +48,6 @@ module WikidataPositionHistory
 
     # Base class for the Inception/Abolition date rows
     class PositionDate
-      # simplified version of a WikidataPositionHistory::Check
-      Warning = Struct.new(:headline, :explanation)
-
       def initialize(metadata)
         @metadata = metadata
       end
@@ -112,14 +112,19 @@ module WikidataPositionHistory
         (implied_list.direct.map(&:qlink) + implied_list.indirect_only.map(&:qlink_i)).join(', ')
       end
 
-      # TODO: add some checks
       def warnings
-        []
+        implied_list.indirect_only.map do |from|
+          Warning.new('Indirect only', "{{PositionHolderHistory/#{indirect_warning_template}|from=#{from.id}|to=#{metadata.position.id}}}")
+        end
       end
 
       private
 
       attr_reader :metadata
+
+      def indirect_warning_template
+        format('warning_indirect_%s', self.class.name.split('::').last.downcase)
+      end
     end
 
     # Data for the position that comes after this one

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -69,27 +69,11 @@ module WikidataPositionHistory
     end
 
     def replaces_combined
-      @replaces_combined ||= ImpliedList.new(replaces_list, derived_replaces_list)
+      @replaces_combined ||= ImpliedList.new(uniq_by_id(:replaces), uniq_by_id(:derived_replaces))
     end
 
     def replaced_by_combined
-      @replaced_by_combined ||= ImpliedList.new(replaced_by_list, derived_replaced_by_list)
-    end
-
-    def replaces_list
-      rows.map(&:replaces).compact.uniq(&:id).sort_by(&:id)
-    end
-
-    def replaced_by_list
-      rows.map(&:replaced_by).compact.uniq(&:id).sort_by(&:id)
-    end
-
-    def derived_replaces_list
-      rows.map(&:derived_replaces).compact.uniq(&:id).sort_by(&:id)
-    end
-
-    def derived_replaced_by_list
-      rows.map(&:derived_replaced_by).compact.uniq(&:id).sort_by(&:id)
+      @replaced_by_combined ||= ImpliedList.new(uniq_by_id(:replaced_by), uniq_by_id(:derived_replaced_by))
     end
 
     def inception_dates
@@ -103,6 +87,10 @@ module WikidataPositionHistory
     private
 
     attr_reader :rows
+
+    def uniq_by_id(method)
+      rows.map(&method).compact.uniq(&:id).sort_by(&:id)
+    end
   end
 
   # The entire wikitext generated for this report

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -35,7 +35,10 @@ module WikidataPositionHistory
         |-
         | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaced by''':
         | style=" border: none; background: #fff; text-align: left;" | <%= metadata.successor.position %>
-        | style=" border: none; background: #fff; text-align: left;" |
+        | style=" border: none; background: #fff; text-align: left;" | \
+        <% metadata.successor.warnings.each do |warning| -%>
+        <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
+        <% end %>
         <% end -%>
         <% if metadata.successor.position || metadata.abolition.date -%>
         |-
@@ -70,7 +73,10 @@ module WikidataPositionHistory
         |-
         | colspan="2" style=" border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaces''':
         | style="border: none; background: #fff; text-align: left;" | <%= metadata.predecessor.position %>
-        | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" |
+        | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
+        <% metadata.predecessor.warnings.each do |warning| -%>
+        <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
+        <% end %>
         <% end -%>
         |}
 

--- a/test/example-data/biodata/Q30533307.json
+++ b/test/example-data/biodata/Q30533307.json
@@ -1,0 +1,35 @@
+{
+  "head" : {
+    "vars" : [ "item", "image" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q495084"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/2018-05-10%20Rainer%20Br%C3%BCderle-7539.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q65539"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Peter%20Altmaier1.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q57789"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Roesler-klein.jpg"
+      }
+    } ]
+  }
+}

--- a/test/example-data/mandates/Q30533307.json
+++ b/test/example-data/mandates/Q30533307.json
@@ -1,0 +1,89 @@
+{
+  "head" : {
+    "vars" : [ "ordinal", "item", "start_date", "start_precision", "end_date", "end_precision", "prev", "next", "nature" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q65539"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-03-14T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q60872"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q57789"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-05-12T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q495084"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2013-12-17T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q495084"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2009-10-28T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q76924"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2011-05-12T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q57789"
+      }
+    } ]
+  }
+}

--- a/test/example-data/metadata/Q13653224.json
+++ b/test/example-data/metadata/Q13653224.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q14211.json
+++ b/test/example-data/metadata/Q14211.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q16147179.json
+++ b/test/example-data/metadata/Q16147179.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q1769526.json
+++ b/test/example-data/metadata/Q1769526.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q1837494.json
+++ b/test/example-data/metadata/Q1837494.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q195965.json
+++ b/test/example-data/metadata/Q195965.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q20530392.json
+++ b/test/example-data/metadata/Q20530392.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {
@@ -43,6 +43,14 @@
         "value" : "http://www.wikidata.org/entity/Q967549"
       },
       "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q61975993"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q967549"
+      },
+      "derivedReplacedBy" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q61975993"
       }

--- a/test/example-data/metadata/Q30533307.json
+++ b/test/example-data/metadata/Q30533307.json
@@ -1,0 +1,35 @@
+{
+  "head" : {
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30533307"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30543192"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q42567912"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q42567912"
+      }
+    } ]
+  }
+}

--- a/test/example-data/metadata/Q3657870.json
+++ b/test/example-data/metadata/Q3657870.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q38780172.json
+++ b/test/example-data/metadata/Q38780172.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {
@@ -43,6 +43,14 @@
         "value" : "http://www.wikidata.org/entity/Q38780315"
       },
       "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q862638"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q38780315"
+      },
+      "derivedReplacedBy" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q862638"
       }

--- a/test/example-data/metadata/Q39055044.json
+++ b/test/example-data/metadata/Q39055044.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q4763428.json
+++ b/test/example-data/metadata/Q4763428.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q5068105.json
+++ b/test/example-data/metadata/Q5068105.json
@@ -1,0 +1,47 @@
+{
+  "head" : {
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5068105"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1922-12-06T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1921-05-03T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4376681"
+      }
+    } ]
+  }
+}

--- a/test/example-data/metadata/Q54211708.json
+++ b/test/example-data/metadata/Q54211708.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q56761097.json
+++ b/test/example-data/metadata/Q56761097.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q67202316.json
+++ b/test/example-data/metadata/Q67202316.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {
@@ -45,6 +45,65 @@
       "replacedBy" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51280630"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
       }
     }, {
       "item" : {
@@ -86,6 +145,473 @@
         "value" : "http://www.wikidata.org/entity/Q67202332"
       },
       "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "derivedReplacedBy" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51280630"
       }
@@ -131,6 +657,14 @@
       "replacedBy" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q50390723"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
       }
     }, {
       "item" : {
@@ -169,11 +703,121 @@
       },
       "replaces" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202332"
+        "value" : "http://www.wikidata.org/entity/Q67202278"
       },
       "replacedBy" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q50390723"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
       }
     } ]
   }

--- a/test/example-data/metadata/Q7444267.json
+++ b/test/example-data/metadata/Q7444267.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q756265.json
+++ b/test/example-data/metadata/Q756265.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/example-data/metadata/Q96424184.json
+++ b/test/example-data/metadata/Q96424184.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
   },
   "results" : {
     "bindings" : [ {

--- a/test/expected-output/Q30533307.out
+++ b/test/expected-output/Q30533307.out
@@ -1,0 +1,37 @@
+== {{Q|Q30533307}} officeholders  ==
+{| class="wikitable" style="text-align: center; border: none;"
+|-
+| colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaced by''':
+| style=" border: none; background: #fff; text-align: left;" | {{Q|Q30543192}}, ''{{Q|Q42567912}}''
+| style=" border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Indirect only</span>&nbsp;<ref>{{PositionHolderHistory/warning_indirect_successor|from=Q42567912|to=Q30533307}}</ref></span>
+|-
+| colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+| colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:Peter%20Altmaier1.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q65539}}</span> 2018-03-14 – 
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Inconsistent predecessor</span>&nbsp;<ref>{{Q|Q65539}} has a {{P|1365}} of {{Q|Q60872}}, but follows {{Q|Q57789}} here</ref></span>
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:Roesler-klein.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q57789}}</span> 2011-05-12 – 2013-12-17
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Missing field</span>&nbsp;<ref>{{Q|Q57789}} is missing {{P|1366}}</ref></span>
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:2018-05-10%20Rainer%20Br%C3%BCderle-7539.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q495084}}</span> 2009-10-28 – 2011-05-12
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Inconsistent predecessor</span>&nbsp;<ref>{{Q|Q495084}} has a {{P|1365}} of {{Q|Q76924}}, but does not follow anyone here</ref></span>
+|-
+| colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+| colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+|-
+| colspan="2" style=" border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaces''':
+| style="border: none; background: #fff; text-align: left;" | ''{{Q|Q42567912}}''
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Indirect only</span>&nbsp;<ref>{{PositionHolderHistory/warning_indirect_predecessor|from=Q42567912|to=Q30533307}}</ref></span>
+|}
+
+<div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
+  <div style="float:right">[https://query.wikidata.org/#%23%20position-mandates%0A%0ASELECT%20DISTINCT%20%3Fordinal%20%3Fitem%20%3Fstart_date%20%3Fstart_precision%20%3Fend_date%20%3Fend_precision%20%3Fprev%20%3Fnext%20%3Fnature%0AWHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%20wd%3AQ5%20%3B%20p%3AP39%20%3Fposn%20.%0A%20%20%3Fposn%20ps%3AP39%20wd%3AQ30533307%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fposn%20wikibase%3Arank%20wikibase%3ADeprecatedRank%20%7D%0A%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP580%20%5B%20wikibase%3AtimeValue%20%3Fstart_date%3B%20wikibase%3AtimePrecision%20%3Fstart_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP582%20%5B%20wikibase%3AtimeValue%20%3Fend_date%3B%20wikibase%3AtimePrecision%20%3Fend_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1365%7Cpq%3AP155%20%3Fprev%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1366%7Cpq%3AP156%20%3Fnext%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1545%20%3Fordinal%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP5102%20%3Fnature%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fstart_date%29%20%3Fitem%0A WDQS]</div>
+</div>
+{{reflist}}

--- a/test/wikidata_position_history/implied_list_spec.rb
+++ b/test/wikidata_position_history/implied_list_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe WikidataPositionHistory::ImpliedList do
+  describe 'direct only' do
+    let(:list) { WikidataPositionHistory::ImpliedList.new(['Q1'], []) }
+
+    it { expect(list.all).must_equal ['Q1'] }
+    it { expect(list.direct_only).must_equal ['Q1'] }
+    it { expect(list.indirect_only).must_equal [] }
+    it { expect(list.both).must_equal [] }
+    it { expect(list.empty?).must_equal false }
+  end
+
+  describe 'indirect only' do
+    let(:list) { WikidataPositionHistory::ImpliedList.new([], ['Q1']) }
+
+    it { expect(list.all).must_equal ['Q1'] }
+    it { expect(list.direct_only).must_equal [] }
+    it { expect(list.indirect_only).must_equal ['Q1'] }
+    it { expect(list.both).must_equal [] }
+  end
+
+  describe 'bidirectional' do
+    let(:list) { WikidataPositionHistory::ImpliedList.new(['Q1'], ['Q1']) }
+
+    it { expect(list.all).must_equal ['Q1'] }
+    it { expect(list.direct_only).must_equal [] }
+    it { expect(list.indirect_only).must_equal [] }
+    it { expect(list.both).must_equal ['Q1'] }
+  end
+
+  describe 'mismatch' do
+    let(:list) { WikidataPositionHistory::ImpliedList.new(['Q1'], ['Q2']) }
+
+    it { expect(list.all).must_equal %w[Q1 Q2] }
+    it { expect(list.direct_only).must_equal ['Q1'] }
+    it { expect(list.indirect_only).must_equal ['Q2'] }
+    it { expect(list.both).must_equal [] }
+  end
+
+  describe 'partial agreement' do
+    let(:list) { WikidataPositionHistory::ImpliedList.new(%w[Q1 Q2], ['Q2']) }
+
+    it { expect(list.all).must_equal %w[Q1 Q2] }
+    it { expect(list.direct_only).must_equal ['Q1'] }
+    it { expect(list.indirect_only).must_equal [] }
+    it { expect(list.both).must_equal ['Q2'] }
+  end
+
+  describe 'overlap' do
+    let(:list) { WikidataPositionHistory::ImpliedList.new(%w[Q1 Q2], %w[Q2 Q3]) }
+
+    it { expect(list.all).must_equal %w[Q1 Q2 Q3] }
+    it { expect(list.direct_only).must_equal ['Q1'] }
+    it { expect(list.indirect_only).must_equal ['Q3'] }
+    it { expect(list.both).must_equal ['Q2'] }
+  end
+
+  describe 'none' do
+    let(:list) { WikidataPositionHistory::ImpliedList.new([], []) }
+
+    it { expect(list.all).must_equal [] }
+    it { expect(list.direct_only).must_equal [] }
+    it { expect(list.indirect_only).must_equal [] }
+    it { expect(list.both).must_equal [] }
+    it { expect(list.empty?).must_equal true }
+  end
+end

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -68,7 +68,11 @@ describe WikidataPositionHistory::Report do
     let(:position_id) { 'Q5068105' }
 
     it { expect(metadata.predecessor.position).must_be_nil }
+    it { expect(metadata.predecessor.warnings).must_be_empty }
     it { expect(metadata.successor.position).must_equal "''{{Q|Q4376681}}''" }
+    it { expect(metadata.successor.warnings.count).must_equal 1 }
+    it { expect(metadata.successor.warnings.first.headline).must_equal 'Indirect only' }
+    it { expect(metadata.successor.warnings.first.explanation).must_equal '{{PositionHolderHistory/warning_indirect_successor|from=Q4376681|to=Q5068105}}' }
   end
 
   describe 'legislative term' do

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -57,11 +57,18 @@ describe WikidataPositionHistory::Report do
     it { expect(metadata.successor.position).must_equal '{{Q|Q862638}}' }
   end
 
-  describe 'office with mutiples replaces and replaced by' do
+  describe 'office with mutiple replaces and replaced by' do
     let(:position_id) { 'Q67202316' }
 
     it { expect(metadata.predecessor.position).must_equal '{{Q|Q67202278}}, {{Q|Q67202332}}' }
     it { expect(metadata.successor.position).must_equal '{{Q|Q50390723}}, {{Q|Q51280630}}' }
+  end
+
+  describe 'office with implied replaces and replaced by' do
+    let(:position_id) { 'Q5068105' }
+
+    it { expect(metadata.predecessor.position).must_be_nil }
+    it { expect(metadata.successor.position).must_equal "''{{Q|Q4376681}}''" }
   end
 
   describe 'legislative term' do

--- a/test/wikidata_position_history/report/wikitext_spec.rb
+++ b/test/wikidata_position_history/report/wikitext_spec.rb
@@ -47,6 +47,12 @@ describe WikidataPositionHistory::Report do
     it { expect(report.wikitext_with_header).must_equal expected }
   end
 
+  describe 'Federal Minister of Economics and Technology' do
+    let(:id) { 'Q30533307' }
+
+    it { expect(report.wikitext_with_header).must_equal expected }
+  end
+
   describe 'Bishop of Worcester' do
     let(:id) { 'Q1837494' }
 


### PR DESCRIPTION
If some other position says that it was replaced by, or replaces, this one, but this one doesn't have the reciprocal link back to that, include it in our list, with an accompanying warning.

Before:
![Screen Shot 2020-09-13 at 17 50 35](https://user-images.githubusercontent.com/57483/93023832-b1f48a80-f5e9-11ea-94e6-9d1a083d15df.png)

After:
![Screen Shot 2020-09-13 at 17 50 02](https://user-images.githubusercontent.com/57483/93023843-c9337800-f5e9-11ea-938f-16af6e1df649.png)
