### PR TITLE
Use new {{QB}} template to link positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# Unreleased
+
+## Enhancements
+
+* Wikidata now has a new {{QB}} template to link to _both_ an Item and
+  its Talk page. As the PositionHolderHistory template for a position
+  often lives on its Talk page, any link to a position item now uses
+  this template, for easier of access to that. (Requested by Tagishsimon:
+  https://twitter.com/Tagishsimon/status/1304363879322079233)
+
 # [1.10.0] 2020-09-13
 
 ## Enhancements

--- a/lib/query_service.rb
+++ b/lib/query_service.rb
@@ -49,8 +49,16 @@ module QueryService
       "{{Q|#{id}}}" if id
     end
 
+    def qblink
+      "{{QB|#{id}}}" if id
+    end
+
     def qlink_i
-      "''{{Q|#{id}}}''" if id
+      "''#{qlink}''" if qlink
+    end
+
+    def qblink_i
+      "''#{qblink}''" if qblink
     end
 
     private

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -109,7 +109,7 @@ module WikidataPositionHistory
       def position
         return if implied_list.empty?
 
-        (implied_list.direct.map(&:qlink) + implied_list.indirect_only.map(&:qlink_i)).join(', ')
+        (implied_list.direct.map(&:qblink) + implied_list.indirect_only.map(&:qblink_i)).join(', ')
       end
 
       def warnings

--- a/test/expected-output/Q30533307.out
+++ b/test/expected-output/Q30533307.out
@@ -2,7 +2,7 @@
 {| class="wikitable" style="text-align: center; border: none;"
 |-
 | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaced by''':
-| style=" border: none; background: #fff; text-align: left;" | {{Q|Q30543192}}, ''{{Q|Q42567912}}''
+| style=" border: none; background: #fff; text-align: left;" | {{QB|Q30543192}}, ''{{QB|Q42567912}}''
 | style=" border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Indirect only</span>&nbsp;<ref>{{PositionHolderHistory/warning_indirect_successor|from=Q42567912|to=Q30533307}}</ref></span>
 |-
 | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
@@ -27,7 +27,7 @@
 | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
 |-
 | colspan="2" style=" border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaces''':
-| style="border: none; background: #fff; text-align: left;" | ''{{Q|Q42567912}}''
+| style="border: none; background: #fff; text-align: left;" | ''{{QB|Q42567912}}''
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Indirect only</span>&nbsp;<ref>{{PositionHolderHistory/warning_indirect_predecessor|from=Q42567912|to=Q30533307}}</ref></span>
 |}
 

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -53,15 +53,15 @@ describe WikidataPositionHistory::Report do
   describe 'office with replaces and replaced by' do
     let(:position_id) { 'Q38780172' }
 
-    it { expect(metadata.predecessor.position).must_equal '{{Q|Q38780315}}' }
-    it { expect(metadata.successor.position).must_equal '{{Q|Q862638}}' }
+    it { expect(metadata.predecessor.position).must_equal '{{QB|Q38780315}}' }
+    it { expect(metadata.successor.position).must_equal '{{QB|Q862638}}' }
   end
 
   describe 'office with mutiple replaces and replaced by' do
     let(:position_id) { 'Q67202316' }
 
-    it { expect(metadata.predecessor.position).must_equal '{{Q|Q67202278}}, {{Q|Q67202332}}' }
-    it { expect(metadata.successor.position).must_equal '{{Q|Q50390723}}, {{Q|Q51280630}}' }
+    it { expect(metadata.predecessor.position).must_equal '{{QB|Q67202278}}, {{QB|Q67202332}}' }
+    it { expect(metadata.successor.position).must_equal '{{QB|Q50390723}}, {{QB|Q51280630}}' }
   end
 
   describe 'office with implied replaces and replaced by' do
@@ -69,7 +69,7 @@ describe WikidataPositionHistory::Report do
 
     it { expect(metadata.predecessor.position).must_be_nil }
     it { expect(metadata.predecessor.warnings).must_be_empty }
-    it { expect(metadata.successor.position).must_equal "''{{Q|Q4376681}}''" }
+    it { expect(metadata.successor.position).must_equal "''{{QB|Q4376681}}''" }
     it { expect(metadata.successor.warnings.count).must_equal 1 }
     it { expect(metadata.successor.warnings.first.headline).must_equal 'Indirect only' }
     it { expect(metadata.successor.warnings.first.explanation).must_equal '{{PositionHolderHistory/warning_indirect_successor|from=Q4376681|to=Q5068105}}' }


### PR DESCRIPTION
This also includes a link to their Talk page, which can be useful if the
PositionHolderHistory template is also included there.

(Requested at https://twitter.com/Tagishsimon/status/1304363879322079233)

Before:
![Screen Shot 2020-09-14 at 12 37 09](https://user-images.githubusercontent.com/57483/93081943-f898c200-f687-11ea-815b-a3867c8b3399.png)

After:
![Screen Shot 2020-09-14 at 12 37 27](https://user-images.githubusercontent.com/57483/93081941-f6cefe80-f687-11ea-8a06-c306a3d87f6f.png)
