### PR TITLE
Use templated warnings for multiple/missing P571/P576

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   this template, for easier of access to that. (Requested by Tagishsimon:
   https://twitter.com/Tagishsimon/status/1304363879322079233)
 
+* The change to how warnings templates work from the last release (i.e.
+  using on-wiki templates, so they can be improved or translated, or used
+  to look for problems via backlinks) definitely seems to have been a good
+  idea, so now the warnings for having an unexpected number of inception
+  or abolition dates have also been adjusted to work the same way.
+
 # [1.10.0] 2020-09-13
 
 ## Enhancements

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -62,8 +62,8 @@ module WikidataPositionHistory
 
       attr_reader :metadata
 
-      def qlink
-        metadata.position.qlink
+      def position_id
+        metadata.position.id
       end
     end
 
@@ -72,10 +72,9 @@ module WikidataPositionHistory
       def warnings
         count = dates.count
         return [] if count == 1
+        return [Warning.new('Missing field', "{{PositionHolderHistory/warning_no_inception_date|item=#{position_id}}}")] if count.zero?
 
-        return [Warning.new('Missing field', "#{qlink} is missing {{P|571}}")] if count.zero?
-
-        [Warning.new('Multiple values', "#{qlink} has more than one {{P|571}}")]
+        [Warning.new('Multiple values', "{{PositionHolderHistory/warning_multiple_inception_dates|item=#{position_id}}}")]
       end
 
       private
@@ -90,7 +89,7 @@ module WikidataPositionHistory
       def warnings
         return [] unless dates.count > 1
 
-        [Warning.new('Multiple values', "#{qlink} has more than one {{P|576}}")]
+        [Warning.new('Multiple values', "{{PositionHolderHistory/warning_multiple_abolition_dates|item=#{position_id}}}")]
       end
 
       private

--- a/test/expected-output/Q3657870.out
+++ b/test/expected-output/Q3657870.out
@@ -3,7 +3,7 @@
 |-
 | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position abolished''':
 | style="border: none; background: #fff; text-align: left;" | 1960 / 1972
-| style="border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Multiple values</span>&nbsp;<ref>{{Q|Q3657870}} has more than one {{P|576}}</ref></span>
+| style="border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Multiple values</span>&nbsp;<ref>{{PositionHolderHistory/warning_multiple_abolition_dates|item=Q3657870}}</ref></span>
 |-
 | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
 | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
@@ -23,7 +23,7 @@
 |-
 | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
 | style="border: none; background: #fff; text-align: left;" | 1957 / 1969
-| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Multiple values</span>&nbsp;<ref>{{Q|Q3657870}} has more than one {{P|571}}</ref></span>
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Multiple values</span>&nbsp;<ref>{{PositionHolderHistory/warning_multiple_inception_dates|item=Q3657870}}</ref></span>
 |}
 
 <div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -32,7 +32,9 @@ describe WikidataPositionHistory::Report do
     it { expect(metadata.abolition.date.to_s).must_equal '1960 / 1972' }
 
     it { expect(metadata.inception.warnings.first.headline).must_equal 'Multiple values' }
+    it { expect(metadata.inception.warnings.first.explanation).must_include 'PositionHolderHistory/warning_multiple_inception_dates' }
     it { expect(metadata.abolition.warnings.first.headline).must_equal 'Multiple values' }
+    it { expect(metadata.abolition.warnings.first.explanation).must_include 'PositionHolderHistory/warning_multiple_abolition_dates' }
   end
 
   describe 'office with neither inception nor abolition date' do
@@ -43,7 +45,7 @@ describe WikidataPositionHistory::Report do
     it { expect(metadata.position?).must_equal true }
 
     it { expect(metadata.inception.warnings.first.headline).must_equal 'Missing field' }
-    it { expect(metadata.inception.warnings.first.explanation).must_include '{{Q|Q96424184}}' }
+    it { expect(metadata.inception.warnings.first.explanation).must_include 'PositionHolderHistory/warning_no_inception_date' }
     it { expect(metadata.abolition.warnings.first).must_be_nil }
 
     it { expect(metadata.predecessor.position).must_be_nil }


### PR DESCRIPTION
Rather than generate the output for these directly in code, call out to an on-wiki template, thus allowing them to be translated, and for the backlinks to be used to look for problems to fix.