### PR TITLE
[refactoring] Remove meaningless 'item' method

### DIFF
--- a/lib/sparql/mandates_query.rb
+++ b/lib/sparql/mandates_query.rb
@@ -37,11 +37,6 @@ module WikidataPositionHistory
       item_from(:item)
     end
 
-    # TODO: rename or remove. 'item' is meaningless/ambiguous
-    def item
-      officeholder.qlink
-    end
-
     # TODO: switch to item_from
     def prev
       QueryService::WikidataItem.new(row.dig(:prev, :value)).qlink

--- a/lib/wikidata_position_history/checks.rb
+++ b/lib/wikidata_position_history/checks.rb
@@ -93,7 +93,7 @@ module WikidataPositionHistory
     # Does the 'replaces' match the previous item in the list?
     class WrongPredecessor < Check
       def problem?
-        earlier_holder? && !!predecessor_qlink && (earlier.item != predecessor_qlink)
+        earlier_holder? && !!predecessor_qlink && (earlier.officeholder.qlink != predecessor_qlink)
       end
 
       def headline
@@ -123,7 +123,7 @@ module WikidataPositionHistory
     # Does the 'replaced by' match the next item in the list?
     class WrongSuccessor < Check
       def problem?
-        later_holder? && !!successor_qlink && (later.item != successor_qlink)
+        later_holder? && !!successor_qlink && (later.officeholder.qlink != successor_qlink)
       end
 
       def headline

--- a/lib/wikidata_position_history/checks.rb
+++ b/lib/wikidata_position_history/checks.rb
@@ -17,11 +17,12 @@ module WikidataPositionHistory
 
     attr_reader :later, :current, :earlier
 
-    def successor
+    # TODO: replace these with objects instead of strings
+    def successor_qlink
       current.next
     end
 
-    def predecessor
+    def predecessor_qlink
       current.prev
     end
 
@@ -92,7 +93,7 @@ module WikidataPositionHistory
     # Does the 'replaces' match the previous item in the list?
     class WrongPredecessor < Check
       def problem?
-        earlier_holder? && !!predecessor && (earlier.item != predecessor)
+        earlier_holder? && !!predecessor_qlink && (earlier.item != predecessor_qlink)
       end
 
       def headline
@@ -100,14 +101,14 @@ module WikidataPositionHistory
       end
 
       def possible_explanation
-        "#{current.officeholder.qlink} has a {{P|1365}} of #{predecessor}, but follows #{earlier.officeholder.qlink} here"
+        "#{current.officeholder.qlink} has a {{P|1365}} of #{predecessor_qlink}, but follows #{earlier.officeholder.qlink} here"
       end
     end
 
     # Is there a 'replaces' but no previous item in the list?
     class MissingPredecessor < Check
       def problem?
-        predecessor && !earlier_holder?
+        predecessor_qlink && !earlier_holder?
       end
 
       def headline
@@ -115,14 +116,14 @@ module WikidataPositionHistory
       end
 
       def possible_explanation
-        "#{current.officeholder.qlink} has a {{P|1365}} of #{predecessor}, but does not follow anyone here"
+        "#{current.officeholder.qlink} has a {{P|1365}} of #{predecessor_qlink}, but does not follow anyone here"
       end
     end
 
     # Does the 'replaced by' match the next item in the list?
     class WrongSuccessor < Check
       def problem?
-        later_holder? && !!successor && (later.item != successor)
+        later_holder? && !!successor_qlink && (later.item != successor_qlink)
       end
 
       def headline
@@ -130,14 +131,14 @@ module WikidataPositionHistory
       end
 
       def possible_explanation
-        "#{current.officeholder.qlink} has a {{P|1366}} of #{successor}, but is followed by #{later.officeholder.qlink} here"
+        "#{current.officeholder.qlink} has a {{P|1366}} of #{successor_qlink}, but is followed by #{later.officeholder.qlink} here"
       end
     end
 
     # Is there a 'replaced by' but no next item in the list?
     class MissingSuccessor < Check
       def problem?
-        successor && !later_holder?
+        successor_qlink && !later_holder?
       end
 
       def headline
@@ -145,7 +146,7 @@ module WikidataPositionHistory
       end
 
       def possible_explanation
-        "#{current.officeholder.qlink} has a {{P|1366}} of #{successor}, but is not followed by anyone here"
+        "#{current.officeholder.qlink} has a {{P|1366}} of #{successor_qlink}, but is not followed by anyone here"
       end
     end
 

--- a/lib/wikidata_position_history/checks.rb
+++ b/lib/wikidata_position_history/checks.rb
@@ -46,7 +46,7 @@ module WikidataPositionHistory
       end
 
       def possible_explanation
-        "#{current.item} is missing #{missing.map { |field| "{{P|#{field_map[field]}}}" }.join(', ')}"
+        "#{current.officeholder.qlink} is missing #{missing.map { |field| "{{P|#{field_map[field]}}}" }.join(', ')}"
       end
 
       def missing
@@ -76,14 +76,14 @@ module WikidataPositionHistory
 
       def expect_prev?
         return unless earlier
-        return if earlier.item == current.item # sucessive terms by same person
+        return if earlier.officeholder.id == current.officeholder.id # sucessive terms by same person
 
         !current.acting?
       end
 
       def expect_next?
         return unless later
-        return if later.item == current.item # sucessive terms by same person
+        return if later.officeholder.id == current.officeholder.id # sucessive terms by same person
 
         !current.acting?
       end
@@ -100,7 +100,7 @@ module WikidataPositionHistory
       end
 
       def possible_explanation
-        "#{current.item} has a {{P|1365}} of #{predecessor}, but follows #{earlier.item} here"
+        "#{current.officeholder.qlink} has a {{P|1365}} of #{predecessor}, but follows #{earlier.officeholder.qlink} here"
       end
     end
 
@@ -115,7 +115,7 @@ module WikidataPositionHistory
       end
 
       def possible_explanation
-        "#{current.item} has a {{P|1365}} of #{predecessor}, but does not follow anyone here"
+        "#{current.officeholder.qlink} has a {{P|1365}} of #{predecessor}, but does not follow anyone here"
       end
     end
 
@@ -130,7 +130,7 @@ module WikidataPositionHistory
       end
 
       def possible_explanation
-        "#{current.item} has a {{P|1366}} of #{successor}, but is followed by #{later.item} here"
+        "#{current.officeholder.qlink} has a {{P|1366}} of #{successor}, but is followed by #{later.officeholder.qlink} here"
       end
     end
 
@@ -145,7 +145,7 @@ module WikidataPositionHistory
       end
 
       def possible_explanation
-        "#{current.item} has a {{P|1366}} of #{successor}, but is not followed by anyone here"
+        "#{current.officeholder.qlink} has a {{P|1366}} of #{successor}, but is not followed by anyone here"
       end
     end
 
@@ -167,7 +167,7 @@ module WikidataPositionHistory
       end
 
       def possible_explanation
-        "#{current.item} has a {{P|582}} of #{current.end_date}, which #{overlap_explanation} the {{P|580}} of #{later.start_date} for #{later.item}"
+        "#{current.officeholder.qlink} has a {{P|582}} of #{current.end_date}, which #{overlap_explanation} the {{P|580}} of #{later.start_date} for #{later.officeholder.qlink}"
       end
 
       protected

--- a/lib/wikidata_position_history/checks.rb
+++ b/lib/wikidata_position_history/checks.rb
@@ -168,7 +168,8 @@ module WikidataPositionHistory
       end
 
       def possible_explanation
-        "#{current.officeholder.qlink} has a {{P|582}} of #{current.end_date}, which #{overlap_explanation} the {{P|580}} of #{later.start_date} for #{later.officeholder.qlink}"
+        format('%s has a {{P|582}} of %s, which %s the {{P|580}} of %s for %s',
+               current.officeholder.qlink, current.end_date, overlap_explanation, later.start_date, later.officeholder.qlink)
       end
 
       protected

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -22,8 +22,8 @@ module WikidataPositionHistory
         "#{ordinal}."
       end
 
-      def person
-        current.item
+      def officeholder
+        current.officeholder
       end
 
       def dates

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -49,7 +49,7 @@ module WikidataPositionHistory
         |-
         | style="padding:0.5em 2em" | <%= mandate.ordinal_string %>
         | style="padding:0.5em 2em" | <%= bio.map(&:image_link).first %>
-        | style="padding:0.5em 2em" | <span style="font-size: <%= mandate.acting? ? '1.25em; font-style: italic;' : '1.5em' %>; display: block;"><%= mandate.person %></span> <%= mandate.dates %>
+        | style="padding:0.5em 2em" | <span style="font-size: <%= mandate.acting? ? '1.25em; font-style: italic;' : '1.5em' %>; display: block;"><%= mandate.officeholder.qlink %></span> <%= mandate.dates %>
         | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
         <% mandate.warnings.each do |warning| -%>
         <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\

--- a/test/wikidata_position_history/checks_spec.rb
+++ b/test/wikidata_position_history/checks_spec.rb
@@ -27,14 +27,14 @@ describe 'Checks' do
     end
 
     it 'warns of inconsistent predecessor' do
-      peel = mandates.index { |result| result&.item == '{{Q|Q181875}}' }
+      peel = mandates.index { |result| result&.officeholder&.id == 'Q181875' }
       check = WikidataPositionHistory::Check::WrongPredecessor.new(*mandates.slice(peel..peel + 2))
       expect(check.problem?).must_equal true
       expect(check.headline).must_equal 'Inconsistent predecessor'
     end
 
     it 'warns of inconsistent successor' do
-      peel = mandates.index { |result| result&.item == '{{Q|Q181875}}' }
+      peel = mandates.index { |result| result&.officeholder&.id == 'Q181875' }
       check = WikidataPositionHistory::Check::WrongSuccessor.new(*mandates.slice(peel..peel + 2))
       expect(check.problem?).must_equal true
       expect(check.headline).must_equal 'Inconsistent successor'


### PR DESCRIPTION
Use objects instead of strings throughout, so we can replace the fairly meaningless `item` method (which is not only ambiguous, but misleading, as it's really a Q-link) with an `officeholder` instead.