### PR TITLE
remove Report#wikitext_with_header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# Unreleased
+
+## Interface change
+
+* `Report#wikitext_with_header` has been removed. This was undocumented,
+  and only used internally, so should not be a breaking change, but if
+  anything *was* using it, that will now break loudly (but, usefully,
+  should also break very early.)
+
 # [1.11.0] 2020-09-14
 
 ## Enhancements

--- a/exe/position-history-for-item
+++ b/exe/position-history-for-item
@@ -8,4 +8,4 @@ if ARGV.size != 1
 e.g. #{$PROGRAM_NAME} Q14211'"
 end
 
-puts WikidataPositionHistory::Report.new(ARGV.first).wikitext_with_header
+puts WikidataPositionHistory::Report.new(ARGV.first).wikitext

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -109,21 +109,6 @@ module WikidataPositionHistory
       template_class.new(template_params).output
     end
 
-    def header
-      "== {{Q|#{position_id}}} officeholders #{position_dates} =="
-    end
-
-    def position_dates
-      dates = [metadata.inception.date, metadata.abolition.date]
-      return '' if dates.compact.empty?
-
-      format('(%s)', dates.join(' – '))
-    end
-
-    def wikitext_with_header
-      [header, wikitext].join("\n")
-    end
-
     def template_params
       {
         metadata:   metadata,

--- a/test/expected-output/Q14211.out
+++ b/test/expected-output/Q14211.out
@@ -1,4 +1,3 @@
-== {{Q|Q14211}} officeholders (1721-04-04 – ) ==
 {| class="wikitable" style="text-align: center; border: none;"
 |-
 | style="padding:0.5em 2em" | 76.

--- a/test/expected-output/Q1837494.out
+++ b/test/expected-output/Q1837494.out
@@ -1,4 +1,3 @@
-== {{Q|Q1837494}} officeholders (680 – ) ==
 {| class="wikitable" style="text-align: center; border: none;"
 |-
 | style="padding:0.5em 2em" | 

--- a/test/expected-output/Q30533307.out
+++ b/test/expected-output/Q30533307.out
@@ -1,4 +1,3 @@
-== {{Q|Q30533307}} officeholders  ==
 {| class="wikitable" style="text-align: center; border: none;"
 |-
 | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaced by''':

--- a/test/expected-output/Q3657870.out
+++ b/test/expected-output/Q3657870.out
@@ -1,4 +1,3 @@
-== {{Q|Q3657870}} officeholders (1957 / 1969 – 1960 / 1972) ==
 {| class="wikitable" style="text-align: center; border: none;"
 |-
 | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position abolished''':

--- a/test/expected-output/Q56761097.out
+++ b/test/expected-output/Q56761097.out
@@ -1,4 +1,3 @@
-== {{Q|Q56761097}} officeholders (1922 – ) ==
 {| class="wikitable" style="text-align: center; border: none;"
 |-
 | style="padding:0.5em 2em" | 14.

--- a/test/expected-output/Q7444267.out
+++ b/test/expected-output/Q7444267.out
@@ -1,4 +1,3 @@
-== {{Q|Q7444267}} officeholders (1920-08-22 – 1945) ==
 {| class="wikitable" style="text-align: center; border: none;"
 |-
 | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position abolished''':

--- a/test/wikidata_position_history/report/dates_spec.rb
+++ b/test/wikidata_position_history/report/dates_spec.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 describe WikidataPositionHistory::Report do
   before { use_sample_data }
 
-  let(:rows) { WikidataPositionHistory::Report.new(position_id).wikitext_with_header.split('|-') }
+  let(:rows) { WikidataPositionHistory::Report.new(position_id).wikitext.split('|-') }
   let(:holder_row) { rows.find { |line| line.include? "#{officeholder}}}</span>" } }
   let(:dates) { holder_row.match(/(?<start>[\ds\-]+)\s–\s(?<end>[\ds-]+)?/).named_captures }
 

--- a/test/wikidata_position_history/report/wikitext_spec.rb
+++ b/test/wikidata_position_history/report/wikitext_spec.rb
@@ -19,43 +19,43 @@ describe WikidataPositionHistory::Report do
   let(:pathname) { Pathname.new("test/expected-output/#{id}.out") }
   let(:expected) do
     # uncomment this to regenerate all the reports
-    # pathname.write report.wikitext_with_header
+    # pathname.write report.wikitext
     pathname.read
   end
 
   describe 'Prime Minister of the United Kingdom' do
     let(:id) { 'Q14211' }
 
-    it { expect(report.wikitext_with_header).must_equal expected }
+    it { expect(report.wikitext).must_equal expected }
   end
 
   describe 'Secretary for Mines' do
     let(:id) { 'Q7444267' }
 
-    it { expect(report.wikitext_with_header).must_equal expected }
+    it { expect(report.wikitext).must_equal expected }
   end
 
   describe 'Ambassador to Albania' do
     let(:id) { 'Q56761097' }
 
-    it { expect(report.wikitext_with_header).must_equal expected }
+    it { expect(report.wikitext).must_equal expected }
   end
 
   describe 'Prime Minister of Ghana' do
     let(:id) { 'Q3657870' }
 
-    it { expect(report.wikitext_with_header).must_equal expected }
+    it { expect(report.wikitext).must_equal expected }
   end
 
   describe 'Federal Minister of Economics and Technology' do
     let(:id) { 'Q30533307' }
 
-    it { expect(report.wikitext_with_header).must_equal expected }
+    it { expect(report.wikitext).must_equal expected }
   end
 
   describe 'Bishop of Worcester' do
     let(:id) { 'Q1837494' }
 
-    it { expect(report.wikitext_with_header).must_equal expected }
+    it { expect(report.wikitext).must_equal expected }
   end
 end


### PR DESCRIPTION
This was really only used internally, and keeping it in sync with the on-wiki equivalent is tricky, as that one goes through the mediawiki templating system. Rather than have special case code here to maintain it, remove it.