### PR TITLE
Display representatives for single-member constituencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   anything *was* using it, that will now break loudly (but, usefully,
   should also break very early.)
 
+## Enhancements
+
+* A {{PositionHolderHistory}} template can now also be added to items
+  representing single-member constituencies, to see the history of
+  representatives for that seat.
+
 # [1.11.0] 2020-09-14
 
 ## Enhancements

--- a/lib/sparql/bio_query.rb
+++ b/lib/sparql/bio_query.rb
@@ -21,6 +21,22 @@ module WikidataPositionHistory
         SPARQL
       end
     end
+
+    # Biographical data for Members for a Constituency
+    class ConstituencyBioQuery < ItemQuery
+      def raw_sparql
+        <<~SPARQL
+          # constituency-biodata
+
+          SELECT DISTINCT ?item ?image
+          WHERE {
+            ?item wdt:P31 wd:Q5 ; p:P39/pq:P768 wd:%s .
+            OPTIONAL { ?item wdt:P18 ?image }
+          }
+          ORDER BY ?item
+        SPARQL
+      end
+    end
   end
 
   # Represents a single row returned from the Position query

--- a/lib/sparql/mandates_query.rb
+++ b/lib/sparql/mandates_query.rb
@@ -25,6 +25,30 @@ module WikidataPositionHistory
         SPARQL
       end
     end
+
+    # SPARQL for fetching all mandates of a single-member district
+    class ConstituencyMandatesQuery < ItemQuery
+      def raw_sparql
+        <<~SPARQL
+          # constituency-mandates
+
+          SELECT DISTINCT ?ordinal ?item ?start_date ?start_precision ?end_date ?end_precision ?prev ?next ?nature
+          WHERE {
+            ?item wdt:P31 wd:Q5 ; p:P39 ?posn .
+            ?posn pq:P768 wd:%s .
+            FILTER NOT EXISTS { ?posn wikibase:rank wikibase:DeprecatedRank }
+
+            OPTIONAL { ?posn pqv:P580 [ wikibase:timeValue ?start_date; wikibase:timePrecision ?start_precision ] }
+            OPTIONAL { ?posn pqv:P582 [ wikibase:timeValue ?end_date; wikibase:timePrecision ?end_precision ] }
+            OPTIONAL { ?posn pq:P1365|pq:P155 ?prev }
+            OPTIONAL { ?posn pq:P1366|pq:P156 ?next }
+            OPTIONAL { ?posn pq:P1545 ?ordinal }
+            OPTIONAL { ?posn pq:P5102 ?nature }
+          }
+          ORDER BY DESC(?start_date) ?item
+        SPARQL
+      end
+    end
   end
 
   # Represents a single row returned from the Mandates query

--- a/lib/sparql/position_query.rb
+++ b/lib/sparql/position_query.rb
@@ -89,7 +89,7 @@ module WikidataPositionHistory
     end
 
     def representative_count
-      raw(:representative_count)
+      raw(:representative_count).to_i
     end
   end
 end

--- a/lib/sparql/position_query.rb
+++ b/lib/sparql/position_query.rb
@@ -11,10 +11,13 @@ module WikidataPositionHistory
           SELECT DISTINCT ?item ?inception ?inception_precision ?abolition ?abolition_precision
                           ?replaces ?replacedBy ?derivedReplaces ?derivedReplacedBy
                           ?isPosition ?isLegislator
+                          ?isConstituency ?representative_count ?legislature
           WHERE {
             VALUES ?item { wd:%s }
             BIND(EXISTS { wd:%s wdt:P279+ wd:Q4164871 } as ?isPosition)
             BIND(EXISTS { wd:%s wdt:P279+ wd:Q4175034 } as ?isLegislator)
+            BIND(EXISTS { wd:%s wdt:P31/wdt:P279+ wd:Q192611 } as ?isConstituency)
+
             OPTIONAL { ?item p:P571 [ a wikibase:BestRank ;
               psv:P571 [ wikibase:timeValue ?inception; wikibase:timePrecision ?inception_precision ]
             ] }
@@ -25,12 +28,16 @@ module WikidataPositionHistory
             OPTIONAL { ?item wdt:P1366 ?replacedBy }
             OPTIONAL { ?derivedReplaces wdt:P1366 ?item }
             OPTIONAL { ?derivedReplacedBy wdt:P1365 ?item }
+
+            OPTIONAL { # if constituency
+              ?item p:P1410 [ a wikibase:BestRank ; ps:P1410 ?representative_count ; pq:P194 ?legislature ]
+            }
           }
         SPARQL
       end
 
       def sparql_args
-        [itemid] * 3
+        [itemid] * 4
       end
     end
   end
@@ -71,6 +78,18 @@ module WikidataPositionHistory
 
     def legislator?
       raw(:isLegislator) == 'true'
+    end
+
+    def constituency?
+      raw(:isConstituency) == 'true'
+    end
+
+    def legislature
+      item_from(:legislature)
+    end
+
+    def representative_count
+      raw(:representative_count)
     end
   end
 end

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -74,7 +74,7 @@ module WikidataPositionHistory
     end
 
     def representative_count
-      rows.map(&:representative_count).map(&:to_i).max
+      rows.map(&:representative_count).max
     end
 
     def replaces_combined
@@ -155,7 +155,7 @@ module WikidataPositionHistory
 
     def wikitext
       return legislator_template if metadata.legislator?
-      return config.multimember_error_template if metadata.constituency? && metadata.representative_count != 1
+      return config.multimember_error_template if metadata.constituency? && (metadata.representative_count != 1)
       return no_items_output if mandates.empty?
 
       template_class.new(template_params).output

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -68,6 +68,11 @@ module WikidataPositionHistory
       rows.map(&:legislator?).first
     end
 
+    def constituency?
+      # this should be the same everywhere
+      rows.map(&:constituency?).first
+    end
+
     def replaces_combined
       @replaces_combined ||= ImpliedList.new(uniq_by_id(:replaces), uniq_by_id(:derived_replaces))
     end
@@ -135,8 +140,14 @@ module WikidataPositionHistory
       [nil, mandates, nil].flatten(1)
     end
 
+    def mandates_query
+      return SPARQL::ConstituencyMandatesQuery if metadata.constituency?
+
+      SPARQL::MandatesQuery
+    end
+
     def sparql
-      @sparql ||= SPARQL::MandatesQuery.new(position_id)
+      @sparql ||= mandates_query.new(position_id)
     end
 
     def mandates

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -129,7 +129,7 @@ module WikidataPositionHistory
     end
 
     def biodata
-      @biodata ||= SPARQL::BioQuery.new(position_id).results_as(BioRow)
+      @biodata ||= biodata_query.new(position_id).results_as(BioRow)
     end
 
     def biodata_for(officeholder)
@@ -144,6 +144,12 @@ module WikidataPositionHistory
       return SPARQL::ConstituencyMandatesQuery if metadata.constituency?
 
       SPARQL::MandatesQuery
+    end
+
+    def biodata_query
+      return SPARQL::ConstituencyBioQuery if metadata.constituency?
+
+      SPARQL::BioQuery
     end
 
     def sparql

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -73,6 +73,10 @@ module WikidataPositionHistory
       rows.map(&:constituency?).first
     end
 
+    def representative_count
+      rows.map(&:representative_count).map(&:to_i).max
+    end
+
     def replaces_combined
       @replaces_combined ||= ImpliedList.new(uniq_by_id(:replaces), uniq_by_id(:derived_replaces))
     end
@@ -133,6 +137,10 @@ module WikidataPositionHistory
       def biodata_query
         SPARQL::ConstituencyBioQuery
       end
+
+      def multimember_error_template
+        "\n{{PositionHolderHistory/error_multimember}}\n"
+      end
     end
   end
 
@@ -147,6 +155,7 @@ module WikidataPositionHistory
 
     def wikitext
       return legislator_template if metadata.legislator?
+      return config.multimember_error_template if metadata.constituency? && metadata.representative_count != 1
       return no_items_output if mandates.empty?
 
       template_class.new(template_params).output

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -176,7 +176,7 @@ module WikidataPositionHistory
     end
 
     def biodata
-      @biodata ||= config.biodata_query.new(position_id).results_as(BioRow)
+      @biodata ||= biodata_sparql.results_as(BioRow)
     end
 
     def biodata_for(officeholder)
@@ -193,6 +193,10 @@ module WikidataPositionHistory
 
     def sparql
       @sparql ||= config.mandates_query.new(position_id)
+    end
+
+    def biodata_sparql
+      config.biodata_query.new(position_id)
     end
 
     def mandates

--- a/test/create_example_data.rb
+++ b/test/create_example_data.rb
@@ -11,6 +11,9 @@ def store(id, dir, query)
 end
 
 id = ARGV.first or abort "Usage: #{$PROGRAM_NAME} <Qid>"
-store(id, 'mandates', WikidataPositionHistory::SPARQL::MandatesQuery.new(id))
+report = WikidataPositionHistory::Report.new(id)
+
 store(id, 'metadata', WikidataPositionHistory::SPARQL::PositionQuery.new(id))
-store(id, 'biodata', WikidataPositionHistory::SPARQL::BioQuery.new(id))
+
+store(id, 'mandates', report.send(:sparql))
+store(id, 'biodata', report.send(:biodata_sparql))

--- a/test/example-data/biodata/Q751651.json
+++ b/test/example-data/biodata/Q751651.json
@@ -1,0 +1,8 @@
+{
+  "head" : {
+    "vars" : [ "item", "image" ]
+  },
+  "results" : {
+    "bindings" : [ ]
+  }
+}

--- a/test/example-data/biodata/Q751651.json
+++ b/test/example-data/biodata/Q751651.json
@@ -3,6 +3,20 @@
     "vars" : [ "item", "image" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1680843"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q300292"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg"
+      }
+    } ]
   }
 }

--- a/test/example-data/mandates/Q751651.json
+++ b/test/example-data/mandates/Q751651.json
@@ -1,0 +1,8 @@
+{
+  "head" : {
+    "vars" : [ "ordinal", "item", "start_date", "start_precision", "end_date", "end_precision", "prev", "next", "nature" ]
+  },
+  "results" : {
+    "bindings" : [ ]
+  }
+}

--- a/test/example-data/mandates/Q751651.json
+++ b/test/example-data/mandates/Q751651.json
@@ -3,6 +3,321 @@
     "vars" : [ "ordinal", "item", "start_date", "start_precision", "end_date", "end_precision", "prev", "next", "nature" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q300292"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2019-12-12T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q300292"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-08T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2019-11-06T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q300292"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-05-07T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-05-03T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q300292"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2010-05-06T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q300292"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2005-05-05T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2010-04-12T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q300292"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-01-05T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2005-04-11T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q300292"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-06-23T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-01-04T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q300292"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2001-06-07T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-06-22T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q300292"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1997-05-01T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2001-05-14T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1680843"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1992-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1997-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1680843"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1987-06-11T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1992-03-16T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1680843"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1986-01-23T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1987-05-18T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1680843"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1983-06-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1985-12-17T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    } ]
   }
 }

--- a/test/example-data/metadata/Q13653224.json
+++ b/test/example-data/metadata/Q13653224.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -27,6 +27,11 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "true"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
       }
     } ]
   }

--- a/test/example-data/metadata/Q14211.json
+++ b/test/example-data/metadata/Q14211.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -24,6 +24,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q1769526.json
+++ b/test/example-data/metadata/Q1769526.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -24,6 +24,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q1837494.json
+++ b/test/example-data/metadata/Q1837494.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -24,6 +24,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q195965.json
+++ b/test/example-data/metadata/Q195965.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -24,6 +24,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q20530392.json
+++ b/test/example-data/metadata/Q20530392.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -34,6 +34,11 @@
         "value" : "false"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q30533307.json
+++ b/test/example-data/metadata/Q30533307.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -14,6 +14,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q3657870.json
+++ b/test/example-data/metadata/Q3657870.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -37,6 +37,11 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
       }
     }, {
       "item" : {
@@ -69,6 +74,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"
@@ -107,6 +117,11 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
       }
     }, {
       "item" : {
@@ -139,6 +154,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q38780172.json
+++ b/test/example-data/metadata/Q38780172.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -34,6 +34,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q39055044.json
+++ b/test/example-data/metadata/Q39055044.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -24,6 +24,11 @@
         "value" : "false"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q4763428.json
+++ b/test/example-data/metadata/Q4763428.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -24,6 +24,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q5068105.json
+++ b/test/example-data/metadata/Q5068105.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -34,6 +34,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q54211708.json
+++ b/test/example-data/metadata/Q54211708.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -14,6 +14,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q56649104.json
+++ b/test/example-data/metadata/Q56649104.json
@@ -6,12 +6,16 @@
     "bindings" : [ {
       "item" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q16147179"
+        "value" : "http://www.wikidata.org/entity/Q56649104"
+      },
+      "legislature" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q783330"
       },
       "isPosition" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
-        "value" : "true"
+        "value" : "false"
       },
       "isLegislator" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
@@ -21,7 +25,7 @@
       "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
-        "value" : "false"
+        "value" : "true"
       }
     } ]
   }

--- a/test/example-data/metadata/Q56649104.json
+++ b/test/example-data/metadata/Q56649104.json
@@ -8,6 +8,11 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q56649104"
       },
+      "representative_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "12"
+      },
       "legislature" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q783330"

--- a/test/example-data/metadata/Q56761097.json
+++ b/test/example-data/metadata/Q56761097.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -24,6 +24,11 @@
         "value" : "false"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q67202316.json
+++ b/test/example-data/metadata/Q67202316.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -38,6 +38,11 @@
         "type" : "literal",
         "value" : "false"
       },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
       "replaces" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q67202278"
@@ -85,6 +90,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"
@@ -140,6 +150,11 @@
         "type" : "literal",
         "value" : "false"
       },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
       "replaces" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q67202332"
@@ -187,6 +202,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"
@@ -242,6 +262,11 @@
         "type" : "literal",
         "value" : "false"
       },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
       "replaces" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q67202278"
@@ -289,6 +314,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"
@@ -344,9 +374,462 @@
         "type" : "literal",
         "value" : "false"
       },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
       "replaces" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51280630"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202332"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50390723"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202316"
+      },
+      "abolition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2004-07-23T00:00:00Z"
+      },
+      "abolition_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2003-05-13T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q67202278"
       },
       "replacedBy" : {
         "type" : "uri",
@@ -395,410 +878,7 @@
         "type" : "literal",
         "value" : "false"
       },
-      "replaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202332"
-      },
-      "replacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q50390723"
-      },
-      "derivedReplaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202332"
-      },
-      "derivedReplacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51280630"
-      }
-    }, {
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202316"
-      },
-      "abolition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2004-07-23T00:00:00Z"
-      },
-      "abolition_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "inception" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2003-05-13T00:00:00Z"
-      },
-      "inception_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "isPosition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "true"
-      },
-      "isLegislator" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "false"
-      },
-      "replaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202332"
-      },
-      "replacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51280630"
-      },
-      "derivedReplaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202278"
-      },
-      "derivedReplacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q50390723"
-      }
-    }, {
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202316"
-      },
-      "abolition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2004-07-23T00:00:00Z"
-      },
-      "abolition_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "inception" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2003-05-13T00:00:00Z"
-      },
-      "inception_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "isPosition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "true"
-      },
-      "isLegislator" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "false"
-      },
-      "replaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202332"
-      },
-      "replacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51280630"
-      },
-      "derivedReplaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202332"
-      },
-      "derivedReplacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q50390723"
-      }
-    }, {
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202316"
-      },
-      "abolition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2004-07-23T00:00:00Z"
-      },
-      "abolition_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "inception" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2003-05-13T00:00:00Z"
-      },
-      "inception_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "isPosition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "true"
-      },
-      "isLegislator" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "false"
-      },
-      "replaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202332"
-      },
-      "replacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51280630"
-      },
-      "derivedReplaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202278"
-      },
-      "derivedReplacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51280630"
-      }
-    }, {
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202316"
-      },
-      "abolition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2004-07-23T00:00:00Z"
-      },
-      "abolition_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "inception" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2003-05-13T00:00:00Z"
-      },
-      "inception_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "isPosition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "true"
-      },
-      "isLegislator" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "false"
-      },
-      "replaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202332"
-      },
-      "replacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51280630"
-      },
-      "derivedReplaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202332"
-      },
-      "derivedReplacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51280630"
-      }
-    }, {
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202316"
-      },
-      "abolition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2004-07-23T00:00:00Z"
-      },
-      "abolition_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "inception" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2003-05-13T00:00:00Z"
-      },
-      "inception_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "isPosition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "true"
-      },
-      "isLegislator" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "false"
-      },
-      "replaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202278"
-      },
-      "replacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q50390723"
-      },
-      "derivedReplaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202278"
-      },
-      "derivedReplacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q50390723"
-      }
-    }, {
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202316"
-      },
-      "abolition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2004-07-23T00:00:00Z"
-      },
-      "abolition_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "inception" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2003-05-13T00:00:00Z"
-      },
-      "inception_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "isPosition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "true"
-      },
-      "isLegislator" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "false"
-      },
-      "replaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202278"
-      },
-      "replacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q50390723"
-      },
-      "derivedReplaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202332"
-      },
-      "derivedReplacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q50390723"
-      }
-    }, {
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202316"
-      },
-      "abolition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2004-07-23T00:00:00Z"
-      },
-      "abolition_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "inception" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2003-05-13T00:00:00Z"
-      },
-      "inception_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "isPosition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "true"
-      },
-      "isLegislator" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "false"
-      },
-      "replaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202278"
-      },
-      "replacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q50390723"
-      },
-      "derivedReplaces" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202278"
-      },
-      "derivedReplacedBy" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51280630"
-      }
-    }, {
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q67202316"
-      },
-      "abolition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2004-07-23T00:00:00Z"
-      },
-      "abolition_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "inception" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
-        "type" : "literal",
-        "value" : "2003-05-13T00:00:00Z"
-      },
-      "inception_precision" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-        "type" : "literal",
-        "value" : "11"
-      },
-      "isPosition" : {
-        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
-        "type" : "literal",
-        "value" : "true"
-      },
-      "isLegislator" : {
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q7444267.json
+++ b/test/example-data/metadata/Q7444267.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -34,6 +34,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q751651.json
+++ b/test/example-data/metadata/Q751651.json
@@ -1,0 +1,47 @@
+{
+  "head" : {
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q751651"
+      },
+      "representative_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "1"
+      },
+      "legislature" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11005"
+      },
+      "inception" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "1983-06-09T00:00:00Z"
+      },
+      "inception_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      }
+    } ]
+  }
+}

--- a/test/example-data/metadata/Q756265.json
+++ b/test/example-data/metadata/Q756265.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -24,6 +24,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/example-data/metadata/Q96424184.json
+++ b/test/example-data/metadata/Q96424184.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -14,6 +14,11 @@
         "value" : "true"
       },
       "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"

--- a/test/expected-output/Q751651.out
+++ b/test/expected-output/Q751651.out
@@ -1,2 +1,76 @@
+{| class="wikitable" style="text-align: center; border: none;"
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2019-12-12 – 
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2017-06-08 – 2019-11-06
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2015-05-07 – 2017-05-03
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2010-05-06 – 2015-03-30
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2005-05-05 – 2010-04-12
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2004-01-05 – 2005-04-11
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2003-06-23 – 2004-01-04
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2001-06-07 – 2003-06-22
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 1997-05-01 – 2001-05-14
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Missing field</span>&nbsp;<ref>{{Q|Q300292}} is missing {{P|1365}}</ref></span>
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1680843}}</span> 1992-04-09 – 1997-04-08
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Missing field</span>&nbsp;<ref>{{Q|Q1680843}} is missing {{P|1366}}</ref></span>
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1680843}}</span> 1987-06-11 – 1992-03-16
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1680843}}</span> 1986-01-23 – 1987-05-18
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1680843}}</span> 1983-06-09 – 1985-12-17
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|-
+| colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
+| style="border: none; background: #fff; text-align: left;" | 1983-06-09
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
+|}
 
-{{PositionHolderHistory/error_no_holders|id=Q751651}}
+<div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
+  <div style="float:right">[https://query.wikidata.org/#%23%20constituency-mandates%0A%0ASELECT%20DISTINCT%20%3Fordinal%20%3Fitem%20%3Fstart_date%20%3Fstart_precision%20%3Fend_date%20%3Fend_precision%20%3Fprev%20%3Fnext%20%3Fnature%0AWHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%20wd%3AQ5%20%3B%20p%3AP39%20%3Fposn%20.%0A%20%20%3Fposn%20pq%3AP768%20wd%3AQ751651%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fposn%20wikibase%3Arank%20wikibase%3ADeprecatedRank%20%7D%0A%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP580%20%5B%20wikibase%3AtimeValue%20%3Fstart_date%3B%20wikibase%3AtimePrecision%20%3Fstart_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP582%20%5B%20wikibase%3AtimeValue%20%3Fend_date%3B%20wikibase%3AtimePrecision%20%3Fend_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1365%7Cpq%3AP155%20%3Fprev%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1366%7Cpq%3AP156%20%3Fnext%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1545%20%3Fordinal%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP5102%20%3Fnature%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fstart_date%29%20%3Fitem%0A WDQS]</div>
+</div>
+{{reflist}}

--- a/test/expected-output/Q751651.out
+++ b/test/expected-output/Q751651.out
@@ -1,0 +1,2 @@
+
+{{PositionHolderHistory/error_no_holders|id=Q751651}}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,6 +40,13 @@ def stub_mandate_query
   end
 end
 
+def stub_constituency_mandate_query
+  stub_request(:get, %r{query.wikidata.org/sparql.*constituency-mandates}).to_return do |request|
+    filename = request.uri.to_s[/pq:P768%20wd:(Q\d+)/, 1]
+    { body: (cached_mandates_path + filename).sub_ext('.json').read }
+  end
+end
+
 def stub_metadata_query
   stub_request(:get, %r{query.wikidata.org/sparql.*position-metadata}).to_return do |request|
     filename = request.uri.to_s[/wd:(Q\d+)/, 1]
@@ -54,8 +61,17 @@ def stub_biodata_query
   end
 end
 
+def stub_constituency_biodata_query
+  stub_request(:get, %r{query.wikidata.org/sparql.*constituency-biodata}).to_return do |request|
+    filename = request.uri.to_s[/pq:P768%20wd:(Q\d+)/, 1]
+    { body: (cached_biodata_path + filename).sub_ext('.json').read }
+  end
+end
+
 def use_sample_data
   stub_mandate_query
+  stub_constituency_mandate_query
   stub_metadata_query
   stub_biodata_query
+  stub_constituency_biodata_query
 end

--- a/test/wikidata_position_history/report/error_templates_spec.rb
+++ b/test/wikidata_position_history/report/error_templates_spec.rb
@@ -14,4 +14,11 @@ describe WikidataPositionHistory::Report do
     result = WikidataPositionHistory::Report.new('Q13653224').wikitext
     expect(result[/{{(.*?)}}/, 1]).must_include 'error_legislator'
   end
+
+  describe 'warning template for a multi-member constituency' do
+    let(:report) { WikidataPositionHistory::Report.new('Q56649104') }
+
+    it { expect(report.send(:metadata).representative_count).must_equal 12 }
+    it { expect(report.wikitext[/{{(.*?)}}/, 1]).must_include 'error_multimember' }
+  end
 end

--- a/test/wikidata_position_history/report/wikitext_spec.rb
+++ b/test/wikidata_position_history/report/wikitext_spec.rb
@@ -53,6 +53,12 @@ describe WikidataPositionHistory::Report do
     it { expect(report.wikitext).must_equal expected }
   end
 
+  describe 'MP for Lagan Valley' do
+    let(:id) { 'Q751651' }
+
+    it { expect(report.wikitext).must_equal expected }
+  end
+
   describe 'Bishop of Worcester' do
     let(:id) { 'Q1837494' }
 


### PR DESCRIPTION
If an item is a single-member constituency show a history of all representatives for that seat:

![image](https://user-images.githubusercontent.com/57483/93318328-7aaef500-f806-11ea-856f-ae8b0b8f3e1a.png)

If it's a constituency, but not explicitly marked as being single-member, explain how to set that:

![Screen Shot 2020-09-16 at 10 15 03](https://user-images.githubusercontent.com/57483/93318394-8b5f6b00-f806-11ea-83da-8d4ddd53bafd.png)

