### PR TITLE
Show 'parliamentary group' column in constituency reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# Unreleased
+
+* When displaying a list of members for a constituency, also include
+  a parliamentary group (P4100) column.
+
 # [2.0.0] 2020-09-16
 
 ## Interface change

--- a/lib/sparql/mandates_query.rb
+++ b/lib/sparql/mandates_query.rb
@@ -32,7 +32,7 @@ module WikidataPositionHistory
         <<~SPARQL
           # constituency-mandates
 
-          SELECT DISTINCT ?ordinal ?item ?start_date ?start_precision ?end_date ?end_precision ?prev ?next ?nature
+          SELECT DISTINCT ?item ?start_date ?start_precision ?end_date ?end_precision ?party ?prev ?nex 
           WHERE {
             ?item wdt:P31 wd:Q5 ; p:P39 ?posn .
             ?posn pq:P768 wd:%s .
@@ -40,10 +40,9 @@ module WikidataPositionHistory
 
             OPTIONAL { ?posn pqv:P580 [ wikibase:timeValue ?start_date; wikibase:timePrecision ?start_precision ] }
             OPTIONAL { ?posn pqv:P582 [ wikibase:timeValue ?end_date; wikibase:timePrecision ?end_precision ] }
-            OPTIONAL { ?posn pq:P1365|pq:P155 ?prev }
-            OPTIONAL { ?posn pq:P1366|pq:P156 ?next }
-            OPTIONAL { ?posn pq:P1545 ?ordinal }
-            OPTIONAL { ?posn pq:P5102 ?nature }
+            OPTIONAL { ?posn pq:P1365 ?prev }
+            OPTIONAL { ?posn pq:P1366 ?next }
+            OPTIONAL { ?posn pq:P4100 ?party }
           }
           ORDER BY DESC(?start_date) ?item
         SPARQL
@@ -59,6 +58,10 @@ module WikidataPositionHistory
 
     def officeholder
       item_from(:item)
+    end
+
+    def party
+      item_from(:party)
     end
 
     # TODO: switch to item_from

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -22,6 +22,10 @@ module WikidataPositionHistory
         "#{ordinal}."
       end
 
+      def party
+        current.party
+      end
+
       def officeholder
         current.officeholder
       end

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -50,6 +50,9 @@ module WikidataPositionHistory
         | style="padding:0.5em 2em" | <%= mandate.ordinal_string %>
         | style="padding:0.5em 2em" | <%= bio.map(&:image_link).first %>
         | style="padding:0.5em 2em" | <span style="font-size: <%= mandate.acting? ? '1.25em; font-style: italic;' : '1.5em' %>; display: block;"><%= mandate.officeholder.qlink %></span> <%= mandate.dates %>
+        <% if metadata.constituency? -%>
+        | style="padding:0.5em 1em" | <% if mandate.party %><%= mandate.party.qlink %><% end %>
+        <% end -%>
         | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
         <% mandate.warnings.each do |warning| -%>
         <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\

--- a/test/example-data/mandates/Q751651.json
+++ b/test/example-data/mandates/Q751651.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "ordinal", "item", "start_date", "start_precision", "end_date", "end_precision", "prev", "next", "nature" ]
+    "vars" : [ "item", "start_date", "start_precision", "end_date", "end_precision", "party", "prev", "nex" ]
   },
   "results" : {
     "bindings" : [ {
@@ -17,6 +17,10 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
         "type" : "literal",
         "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q215519"
       }
     }, {
       "item" : {
@@ -32,6 +36,10 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
         "type" : "literal",
         "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q215519"
       },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -58,6 +66,10 @@
         "type" : "literal",
         "value" : "11"
       },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q215519"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -82,6 +94,10 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
         "type" : "literal",
         "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q215519"
       },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -108,6 +124,10 @@
         "type" : "literal",
         "value" : "11"
       },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q215519"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -132,6 +152,10 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
         "type" : "literal",
         "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q215519"
       },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -158,6 +182,10 @@
         "type" : "literal",
         "value" : "11"
       },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q327591"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -182,6 +210,10 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
         "type" : "literal",
         "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841045"
       },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -208,6 +240,10 @@
         "type" : "literal",
         "value" : "11"
       },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841045"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -232,6 +268,10 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
         "type" : "literal",
         "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841045"
       },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -258,6 +298,10 @@
         "type" : "literal",
         "value" : "11"
       },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841045"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -283,6 +327,10 @@
         "type" : "literal",
         "value" : "11"
       },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841045"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -307,6 +355,10 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
         "type" : "literal",
         "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q841045"
       },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",

--- a/test/expected-output/Q751651.out
+++ b/test/expected-output/Q751651.out
@@ -3,66 +3,79 @@
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2019-12-12 – 
+| style="padding:0.5em 1em" | {{Q|Q215519}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2017-06-08 – 2019-11-06
+| style="padding:0.5em 1em" | {{Q|Q215519}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2015-05-07 – 2017-05-03
+| style="padding:0.5em 1em" | {{Q|Q215519}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2010-05-06 – 2015-03-30
+| style="padding:0.5em 1em" | {{Q|Q215519}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2005-05-05 – 2010-04-12
+| style="padding:0.5em 1em" | {{Q|Q215519}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2004-01-05 – 2005-04-11
+| style="padding:0.5em 1em" | {{Q|Q215519}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2003-06-23 – 2004-01-04
+| style="padding:0.5em 1em" | {{Q|Q327591}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2001-06-07 – 2003-06-22
+| style="padding:0.5em 1em" | {{Q|Q841045}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 1997-05-01 – 2001-05-14
+| style="padding:0.5em 1em" | {{Q|Q841045}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Missing field</span>&nbsp;<ref>{{Q|Q300292}} is missing {{P|1365}}</ref></span>
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1680843}}</span> 1992-04-09 – 1997-04-08
+| style="padding:0.5em 1em" | {{Q|Q841045}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Missing field</span>&nbsp;<ref>{{Q|Q1680843}} is missing {{P|1366}}</ref></span>
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1680843}}</span> 1987-06-11 – 1992-03-16
+| style="padding:0.5em 1em" | {{Q|Q841045}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1680843}}</span> 1986-01-23 – 1987-05-18
+| style="padding:0.5em 1em" | {{Q|Q841045}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1680843}}</span> 1983-06-09 – 1985-12-17
+| style="padding:0.5em 1em" | {{Q|Q841045}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
 | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
@@ -71,6 +84,6 @@
 |}
 
 <div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
-  <div style="float:right">[https://query.wikidata.org/#%23%20constituency-mandates%0A%0ASELECT%20DISTINCT%20%3Fordinal%20%3Fitem%20%3Fstart_date%20%3Fstart_precision%20%3Fend_date%20%3Fend_precision%20%3Fprev%20%3Fnext%20%3Fnature%0AWHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%20wd%3AQ5%20%3B%20p%3AP39%20%3Fposn%20.%0A%20%20%3Fposn%20pq%3AP768%20wd%3AQ751651%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fposn%20wikibase%3Arank%20wikibase%3ADeprecatedRank%20%7D%0A%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP580%20%5B%20wikibase%3AtimeValue%20%3Fstart_date%3B%20wikibase%3AtimePrecision%20%3Fstart_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP582%20%5B%20wikibase%3AtimeValue%20%3Fend_date%3B%20wikibase%3AtimePrecision%20%3Fend_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1365%7Cpq%3AP155%20%3Fprev%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1366%7Cpq%3AP156%20%3Fnext%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1545%20%3Fordinal%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP5102%20%3Fnature%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fstart_date%29%20%3Fitem%0A WDQS]</div>
+  <div style="float:right">[https://query.wikidata.org/#%23%20constituency-mandates%0A%0ASELECT%20DISTINCT%20%3Fitem%20%3Fstart_date%20%3Fstart_precision%20%3Fend_date%20%3Fend_precision%20%3Fparty%20%3Fprev%20%3Fnex%20%0AWHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%20wd%3AQ5%20%3B%20p%3AP39%20%3Fposn%20.%0A%20%20%3Fposn%20pq%3AP768%20wd%3AQ751651%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fposn%20wikibase%3Arank%20wikibase%3ADeprecatedRank%20%7D%0A%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP580%20%5B%20wikibase%3AtimeValue%20%3Fstart_date%3B%20wikibase%3AtimePrecision%20%3Fstart_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP582%20%5B%20wikibase%3AtimeValue%20%3Fend_date%3B%20wikibase%3AtimePrecision%20%3Fend_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1365%20%3Fprev%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1366%20%3Fnext%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP4100%20%3Fparty%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fstart_date%29%20%3Fitem%0A WDQS]</div>
 </div>
 {{reflist}}

--- a/test/wikidata_position_history/report/single_member_district_spec.rb
+++ b/test/wikidata_position_history/report/single_member_district_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe WikidataPositionHistory::Report do
+  before { use_sample_data }
+
+  let(:lines) { WikidataPositionHistory::Report.new('Q751651').template_params[:table_rows] }
+  let(:mandates) { lines.map { |line| line[:mandate] } }
+  let(:donaldson_mandates) { mandates.select { |mandate| mandate.officeholder.id == 'Q300292' } }
+
+  it 'has two distinct MPs' do
+    expect(mandates.map(&:officeholder).uniq(&:id).count).must_equal 2
+  end
+
+  it 'has lots of Donaldson mandates' do
+    expect(donaldson_mandates.count).must_equal 9
+  end
+
+  it 'has Donaldson in multiple different parties' do
+    # DUP / Independent / UUP
+    expect(donaldson_mandates.map(&:party).map(&:id).uniq.to_set).must_equal %w[Q215519 Q327591 Q841045].to_set
+  end
+end


### PR DESCRIPTION
Also display any P4100 ('parliamentary group') qualifier:

![Screen Shot 2020-09-16 at 19 00 13](https://user-images.githubusercontent.com/57483/93374648-e4eb8800-f84e-11ea-9373-691fc3f9dadb.png)
