### PR TITLE
Use term ordinals in constituency reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 # Unreleased
 
 * When displaying a list of members for a constituency, also include
-  a parliamentary group (P4100) column.
+  a 'parliamentary group' (P4100) column, and if there's a
+  'parliamentary term' (P2937) qualifier, use it for the ordinal.
 
 # [2.0.0] 2020-09-16
 

--- a/lib/sparql/mandates_query.rb
+++ b/lib/sparql/mandates_query.rb
@@ -32,7 +32,7 @@ module WikidataPositionHistory
         <<~SPARQL
           # constituency-mandates
 
-          SELECT DISTINCT ?item ?start_date ?start_precision ?end_date ?end_precision ?party ?prev ?nex 
+          SELECT DISTINCT ?ordinal ?item ?start_date ?start_precision ?end_date ?end_precision ?party ?prev ?next ?term
           WHERE {
             ?item wdt:P31 wd:Q5 ; p:P39 ?posn .
             ?posn pq:P768 wd:%s .
@@ -43,6 +43,10 @@ module WikidataPositionHistory
             OPTIONAL { ?posn pq:P1365 ?prev }
             OPTIONAL { ?posn pq:P1366 ?next }
             OPTIONAL { ?posn pq:P4100 ?party }
+            OPTIONAL {
+              ?posn pq:P2937 ?term .
+              OPTIONAL { ?term p:P31/pq:P1545 ?ordinal }
+            }
           }
           ORDER BY DESC(?start_date) ?item
         SPARQL

--- a/test/example-data/mandates/Q751651.json
+++ b/test/example-data/mandates/Q751651.json
@@ -1,9 +1,13 @@
 {
   "head" : {
-    "vars" : [ "item", "start_date", "start_precision", "end_date", "end_precision", "party", "prev", "nex" ]
+    "vars" : [ "ordinal", "item", "start_date", "start_precision", "end_date", "end_precision", "party", "prev", "next", "term" ]
   },
   "results" : {
     "bindings" : [ {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "58"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q300292"
@@ -21,8 +25,16 @@
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q215519"
+      },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q77685395"
       }
     }, {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "57"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q300292"
@@ -41,6 +53,10 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q215519"
       },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q29974940"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -52,6 +68,10 @@
         "value" : "11"
       }
     }, {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "56"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q300292"
@@ -70,6 +90,10 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q215519"
       },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21084473"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -81,6 +105,10 @@
         "value" : "11"
       }
     }, {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "55"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q300292"
@@ -99,6 +127,10 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q215519"
       },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21084472"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -110,6 +142,10 @@
         "value" : "11"
       }
     }, {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "54"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q300292"
@@ -128,6 +164,10 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q215519"
       },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21084471"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -139,6 +179,10 @@
         "value" : "11"
       }
     }, {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "53"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q300292"
@@ -157,6 +201,10 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q215519"
       },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21084470"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -168,6 +216,10 @@
         "value" : "11"
       }
     }, {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "53"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q300292"
@@ -186,6 +238,10 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q327591"
       },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21084470"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -197,6 +253,10 @@
         "value" : "11"
       }
     }, {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "53"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q300292"
@@ -215,6 +275,10 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q841045"
       },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21084470"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -226,6 +290,10 @@
         "value" : "11"
       }
     }, {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "52"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q300292"
@@ -244,6 +312,10 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q841045"
       },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21084469"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -255,6 +327,10 @@
         "value" : "11"
       }
     }, {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "51"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q1680843"
@@ -273,6 +349,10 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q841045"
       },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21084468"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -284,6 +364,10 @@
         "value" : "11"
       }
     }, {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "50"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q1680843"
@@ -302,6 +386,10 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q841045"
       },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21084467"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -313,6 +401,10 @@
         "value" : "11"
       }
     }, {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "49"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q1680843"
@@ -331,6 +423,10 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q841045"
       },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21084466"
+      },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
@@ -342,6 +438,10 @@
         "value" : "11"
       }
     }, {
+      "ordinal" : {
+        "type" : "literal",
+        "value" : "49"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q1680843"
@@ -359,6 +459,10 @@
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q841045"
+      },
+      "term" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21084466"
       },
       "end_date" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",

--- a/test/expected-output/Q751651.out
+++ b/test/expected-output/Q751651.out
@@ -1,78 +1,78 @@
 {| class="wikitable" style="text-align: center; border: none;"
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 58.
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2019-12-12 – 
 | style="padding:0.5em 1em" | {{Q|Q215519}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 57.
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2017-06-08 – 2019-11-06
 | style="padding:0.5em 1em" | {{Q|Q215519}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 56.
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2015-05-07 – 2017-05-03
 | style="padding:0.5em 1em" | {{Q|Q215519}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 55.
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2010-05-06 – 2015-03-30
 | style="padding:0.5em 1em" | {{Q|Q215519}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 54.
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2005-05-05 – 2010-04-12
 | style="padding:0.5em 1em" | {{Q|Q215519}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 53.
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2004-01-05 – 2005-04-11
 | style="padding:0.5em 1em" | {{Q|Q215519}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 53.
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2003-06-23 – 2004-01-04
 | style="padding:0.5em 1em" | {{Q|Q327591}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 53.
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 2001-06-07 – 2003-06-22
 | style="padding:0.5em 1em" | {{Q|Q841045}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 52.
 | style="padding:0.5em 2em" | [[File:Official%20portrait%20of%20Sir%20Jeffrey%20M.%20Donaldson%20crop%202.jpg|75px]]
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q300292}}</span> 1997-05-01 – 2001-05-14
 | style="padding:0.5em 1em" | {{Q|Q841045}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Missing field</span>&nbsp;<ref>{{Q|Q300292}} is missing {{P|1365}}</ref></span>
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 51.
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1680843}}</span> 1992-04-09 – 1997-04-08
 | style="padding:0.5em 1em" | {{Q|Q841045}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Missing field</span>&nbsp;<ref>{{Q|Q1680843}} is missing {{P|1366}}</ref></span>
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 50.
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1680843}}</span> 1987-06-11 – 1992-03-16
 | style="padding:0.5em 1em" | {{Q|Q841045}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 49.
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1680843}}</span> 1986-01-23 – 1987-05-18
 | style="padding:0.5em 1em" | {{Q|Q841045}}
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | 
 |-
-| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | 49.
 | style="padding:0.5em 2em" | 
 | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1680843}}</span> 1983-06-09 – 1985-12-17
 | style="padding:0.5em 1em" | {{Q|Q841045}}
@@ -84,6 +84,6 @@
 |}
 
 <div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
-  <div style="float:right">[https://query.wikidata.org/#%23%20constituency-mandates%0A%0ASELECT%20DISTINCT%20%3Fitem%20%3Fstart_date%20%3Fstart_precision%20%3Fend_date%20%3Fend_precision%20%3Fparty%20%3Fprev%20%3Fnex%20%0AWHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%20wd%3AQ5%20%3B%20p%3AP39%20%3Fposn%20.%0A%20%20%3Fposn%20pq%3AP768%20wd%3AQ751651%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fposn%20wikibase%3Arank%20wikibase%3ADeprecatedRank%20%7D%0A%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP580%20%5B%20wikibase%3AtimeValue%20%3Fstart_date%3B%20wikibase%3AtimePrecision%20%3Fstart_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP582%20%5B%20wikibase%3AtimeValue%20%3Fend_date%3B%20wikibase%3AtimePrecision%20%3Fend_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1365%20%3Fprev%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1366%20%3Fnext%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP4100%20%3Fparty%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fstart_date%29%20%3Fitem%0A WDQS]</div>
+  <div style="float:right">[https://query.wikidata.org/#%23%20constituency-mandates%0A%0ASELECT%20DISTINCT%20%3Fordinal%20%3Fitem%20%3Fstart_date%20%3Fstart_precision%20%3Fend_date%20%3Fend_precision%20%3Fparty%20%3Fprev%20%3Fnext%20%3Fterm%0AWHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%20wd%3AQ5%20%3B%20p%3AP39%20%3Fposn%20.%0A%20%20%3Fposn%20pq%3AP768%20wd%3AQ751651%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fposn%20wikibase%3Arank%20wikibase%3ADeprecatedRank%20%7D%0A%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP580%20%5B%20wikibase%3AtimeValue%20%3Fstart_date%3B%20wikibase%3AtimePrecision%20%3Fstart_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP582%20%5B%20wikibase%3AtimeValue%20%3Fend_date%3B%20wikibase%3AtimePrecision%20%3Fend_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1365%20%3Fprev%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1366%20%3Fnext%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP4100%20%3Fparty%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20%3Fposn%20pq%3AP2937%20%3Fterm%20.%0A%20%20%20%20OPTIONAL%20%7B%20%3Fterm%20p%3AP31%2Fpq%3AP1545%20%3Fordinal%20%7D%0A%20%20%7D%0A%7D%0AORDER%20BY%20DESC%28%3Fstart_date%29%20%3Fitem%0A WDQS]</div>
 </div>
 {{reflist}}

--- a/test/wikidata_position_history/report/single_member_district_spec.rb
+++ b/test/wikidata_position_history/report/single_member_district_spec.rb
@@ -13,6 +13,10 @@ describe WikidataPositionHistory::Report do
     expect(mandates.map(&:officeholder).uniq(&:id).count).must_equal 2
   end
 
+  it 'has term ordinals' do
+    expect(mandates.count { |mandate| mandate.ordinal_string == '53.' }).must_equal 3
+  end
+
   it 'has lots of Donaldson mandates' do
     expect(donaldson_mandates.count).must_equal 9
   end


### PR DESCRIPTION
If there's a P2937 'legislative term' qualifier, and that in turn has an ordinal, treat that as the ordinal for the mandate.

![Screen Shot 2020-09-16 at 19 12 03](https://user-images.githubusercontent.com/57483/93376166-1ebd8e00-f851-11ea-8ddc-a8a61dc5b2af.png)
