### PR TITLE
Display multiple positions as list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
+# Unreleased
+
+## Enhancements
+
+* When a position has more than one successor or prdecessor, those will
+  now be displayed as a proper Mediawiki list, rather than one long line
+  of text. As these are in a table cell, this should stop those growing
+  unnecessarily wide, and should generally make everything look a little
+  nicer.
+
 # [2.1.0] 2020-09-16
+
+## Enhancements
 
 * When displaying a list of members for a constituency, also include
   a 'parliamentary group' (P4100) column, and if there's a

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -112,7 +112,10 @@ module WikidataPositionHistory
       def position
         return if implied_list.empty?
 
-        (implied_list.direct.map(&:qblink) + implied_list.indirect_only.map(&:qblink_i)).join(', ')
+        list = (implied_list.direct.map(&:qblink) + implied_list.indirect_only.map(&:qblink_i))
+        return list.first if list.count == 1
+
+        list.map { |item| "\n* #{item}" }.join
       end
 
       def warnings

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -33,8 +33,8 @@ module WikidataPositionHistory
         <% end -%>
         <% if metadata.successor.position -%>
         |-
-        | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaced by''':
-        | style=" border: none; background: #fff; text-align: left;" | <%= metadata.successor.position %>
+        | colspan="2" style="border: none; background: #fff; font-size: 1.15em; vertical-align: baseline; text-align: right;" | '''Replaced by''':
+        | style=" border: none; background: #fff; vertical-align: baseline; text-align: left;" | <%= metadata.successor.position %>
         | style=" border: none; background: #fff; text-align: left;" | \
         <% metadata.successor.warnings.each do |warning| -%>
         <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\

--- a/test/expected-output/Q30533307.out
+++ b/test/expected-output/Q30533307.out
@@ -1,7 +1,9 @@
 {| class="wikitable" style="text-align: center; border: none;"
 |-
-| colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaced by''':
-| style=" border: none; background: #fff; text-align: left;" | {{QB|Q30543192}}, ''{{QB|Q42567912}}''
+| colspan="2" style="border: none; background: #fff; font-size: 1.15em; vertical-align: baseline; text-align: right;" | '''Replaced by''':
+| style=" border: none; background: #fff; vertical-align: baseline; text-align: left;" | 
+* {{QB|Q30543192}}
+* ''{{QB|Q42567912}}''
 | style=" border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Indirect only</span>&nbsp;<ref>{{PositionHolderHistory/warning_indirect_successor|from=Q42567912|to=Q30533307}}</ref></span>
 |-
 | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -62,8 +62,10 @@ describe WikidataPositionHistory::Report do
   describe 'office with mutiple replaces and replaced by' do
     let(:position_id) { 'Q67202316' }
 
-    it { expect(metadata.predecessor.position).must_equal '{{QB|Q67202278}}, {{QB|Q67202332}}' }
-    it { expect(metadata.successor.position).must_equal '{{QB|Q50390723}}, {{QB|Q51280630}}' }
+    it { expect(metadata.predecessor.position).must_include '{{QB|Q67202278}}' }
+    it { expect(metadata.predecessor.position).must_include '{{QB|Q67202332}}' }
+    it { expect(metadata.successor.position).must_include '{{QB|Q50390723}}' }
+    it { expect(metadata.successor.position).must_include '{{QB|Q51280630}}' }
   end
 
   describe 'office with implied replaces and replaced by' do


### PR DESCRIPTION
Where there is more than one predecessor or successor position, display them as a Mediawiki list, rather than joined by commas.

This gives a clearer visual layout.

Before:
![Screen Shot 2020-09-17 at 07 45 05](https://user-images.githubusercontent.com/57483/93429910-c5d61000-f8b9-11ea-9054-07c9b9444657.png)

After:
![Screen Shot 2020-09-17 at 07 58 13](https://user-images.githubusercontent.com/57483/93431223-beb00180-f8bb-11ea-95e6-0b59e0ee4317.png)


