### PR TITLE
Display warning if no P571 inception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Enhancements
 
+* Every position came into existence at _some_ point, and so should have
+  a P571 inception date. If that's missing, a warning will now be
+  displayed.
+
+## Improvements
+
 * When a position has more than one successor or prdecessor, those will
   now be displayed as a proper Mediawiki list, rather than one long line
   of text. As these are in a table cell, this should stop those growing

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -63,7 +63,7 @@ module WikidataPositionHistory
         | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
         | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
         <% end -%>
-        <% if metadata.inception.date -%>
+        <% if metadata.inception.date || metadata.inception.warnings.any? -%>
         |-
         | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
         | style="border: none; background: #fff; text-align: left;" | <%= metadata.inception.date %>

--- a/test/expected-output/Q30533307.out
+++ b/test/expected-output/Q30533307.out
@@ -27,6 +27,10 @@
 | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
 | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
 |-
+| colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
+| style="border: none; background: #fff; text-align: left;" | 
+| style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Missing field</span>&nbsp;<ref>{{PositionHolderHistory/warning_no_inception_date|item=Q30533307}}</ref></span>
+|-
 | colspan="2" style=" border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaces''':
 | style="border: none; background: #fff; text-align: left;" | ''{{QB|Q42567912}}''
 | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;">Indirect only</span>&nbsp;<ref>{{PositionHolderHistory/warning_indirect_predecessor|from=Q42567912|to=Q30533307}}</ref></span>


### PR DESCRIPTION
If a position does not have any P571 inception date claims, display a (templated) warning.

![Screen Shot 2020-09-17 at 09 09 21](https://user-images.githubusercontent.com/57483/93438656-831a3500-f8c5-11ea-9c39-e1af5882fb9a.png)
