### PR TITLE
optionally set a bot flag on edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# Unreleased
+
+## Improvements
+
+* Edits on Wikidata can now set a botflag if requested, based on the
+  `PHH_BOT` environemnt variable.
+
 # [2.2.0] 2020-09-18
 
 ## Enhancements

--- a/lib/wikidata_position_history.rb
+++ b/lib/wikidata_position_history.rb
@@ -16,6 +16,18 @@ require 'date'
 require 'mediawiki/client'
 require 'mediawiki/page'
 
+module MediaWiki
+  # mediawiki-page-replaceable_content does not provide a way to set a
+  # bot flag, so we need to monkey patch it. This should really be
+  # exposed somewhere in its interface.
+  class Client
+    def edit(hash)
+      hash['bot'] = ENV['PHH_BOT'] if ENV.key?('PHH_BOT')
+      wrapped_client.edit(hash)
+    end
+  end
+end
+
 module WikidataPositionHistory
   # Rewrites a Wiki page
   class PageRewriter


### PR DESCRIPTION
If the PHH_BOT environment variable is set, use it to set a 'bot' flag on
edits (per https://www.mediawiki.org/wiki/API:Edit)

This involves monkey-patching mediawiki-page-replaceable_content, which is
far from ideal, but its interface doesn't offer a way to do this, and
creating one there would involve changing that interface quite 
substantially.