### PR TITLE
Use named parameters for ERB.new

### DIFF
--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -16,7 +16,7 @@ module WikidataPositionHistory
     attr_reader :data
 
     def template
-      @template ||= ERB.new(template_text, nil, '-')
+      @template ||= ERB.new(template_text, trim_mode: '-')
     end
 
     def template_text


### PR DESCRIPTION
passing trim_mode as a third parameter is now deprecated.
