### PR TITLE
Add report for a legislative term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+* Items that are legislative terms can now be detected.
+
 # [2.3.0] 2020-10-01
 
 * Edits on Wikidata can now set a botflag if requested, based on the

--- a/lib/sparql/bio_query.rb
+++ b/lib/sparql/bio_query.rb
@@ -37,6 +37,22 @@ module WikidataPositionHistory
         SPARQL
       end
     end
+
+    # Biographical data for Members during a Term
+    class TermBioQuery < ItemQuery
+      def raw_sparql
+        <<~SPARQL
+          # term-biodata
+
+          SELECT DISTINCT ?item ?image
+          WHERE {
+            ?item wdt:P31 wd:Q5 ; p:P39/pq:P2937 wd:%s .
+            OPTIONAL { ?item wdt:P18 ?image }
+          }
+          ORDER BY ?item
+        SPARQL
+      end
+    end
   end
 
   # Represents a single row returned from the Position query

--- a/lib/sparql/mandates_query.rb
+++ b/lib/sparql/mandates_query.rb
@@ -52,6 +52,32 @@ module WikidataPositionHistory
         SPARQL
       end
     end
+
+    # SPARQL for fetching all mandates during a legislative term
+    class TermMandatesQuery < ItemQuery
+      def raw_sparql
+        <<~SPARQL
+          # term-mandates
+
+          SELECT DISTINCT ?item ?start_date ?start_precision ?end_date ?end_precision ?prev ?next ?party ?district ?endCause
+          WHERE {
+            ?item wdt:P31 wd:Q5 ; p:P39 ?posn .
+            ?posn ps:P39 ?position .
+            ?posn pq:P2937 wd:%s .
+            FILTER NOT EXISTS { ?posn wikibase:rank wikibase:DeprecatedRank }
+
+            OPTIONAL { ?posn pqv:P580 [ wikibase:timeValue ?start_date; wikibase:timePrecision ?start_precision ] }
+            OPTIONAL { ?posn pqv:P582 [ wikibase:timeValue ?end_date; wikibase:timePrecision ?end_precision ] }
+            OPTIONAL { ?posn pq:P1365|pq:P155 ?prev }
+            OPTIONAL { ?posn pq:P1366|pq:P156 ?next }
+            OPTIONAL { ?posn pq:P4100 ?party }
+            OPTIONAL { ?posn pq:P768 ?district }
+            OPTIONAL { ?posn pq:P1534 ?endCause }
+          }
+          ORDER BY ?start_date ?item
+        SPARQL
+      end
+    end
   end
 
   # Represents a single row returned from the Mandates query
@@ -93,6 +119,17 @@ module WikidataPositionHistory
 
     def end_date
       date_from(:end_date, :end_precision)
+    end
+  end
+
+  # Represents a single row returned from the TermMandates query
+  class TermMandateRow < MandateRow
+    def district
+      QueryService::WikidataItem.new(row.dig(:district, :value))
+    end
+
+    def end_cause
+      QueryService::WikidataItem.new(row.dig(:endCause, :value))
     end
   end
 end

--- a/lib/sparql/position_query.rb
+++ b/lib/sparql/position_query.rb
@@ -10,13 +10,14 @@ module WikidataPositionHistory
 
           SELECT DISTINCT ?item ?inception ?inception_precision ?abolition ?abolition_precision
                           ?replaces ?replacedBy ?derivedReplaces ?derivedReplacedBy
-                          ?isPosition ?isLegislator
+                          ?isPosition ?isLegislator ?isTerm
                           ?isConstituency ?representative_count ?legislature
           WHERE {
             VALUES ?item { wd:%s }
             BIND(EXISTS { wd:%s wdt:P279+ wd:Q4164871 } as ?isPosition)
             BIND(EXISTS { wd:%s wdt:P279+ wd:Q4175034 } as ?isLegislator)
-            BIND(EXISTS { wd:%s wdt:P31/wdt:P279+ wd:Q192611 } as ?isConstituency)
+            BIND(EXISTS { wd:%s wdt:P31/wdt:P279* wd:Q15238777 } as ?isTerm)
+            BIND(EXISTS { wd:%s wdt:P31/wdt:P279* wd:Q192611 } as ?isConstituency)
 
             OPTIONAL { ?item p:P571 [ a wikibase:BestRank ;
               psv:P571 [ wikibase:timeValue ?inception; wikibase:timePrecision ?inception_precision ]
@@ -37,7 +38,7 @@ module WikidataPositionHistory
       end
 
       def sparql_args
-        [itemid] * 4
+        [itemid] * 5
       end
     end
   end
@@ -74,8 +75,9 @@ module WikidataPositionHistory
 
     def type
       return 'constituency' if raw(:isConstituency) == 'true'
-      return 'legislator' if raw(:isLegislator) == 'true'
-      return 'position' if raw(:isPosition) == 'true'
+      return 'legislator'   if raw(:isLegislator) == 'true'
+      return 'term'         if raw(:isTerm) == 'true'
+      return 'position'     if raw(:isPosition) == 'true'
     end
 
     def legislature

--- a/lib/wikidata_position_history/output_row.rb
+++ b/lib/wikidata_position_history/output_row.rb
@@ -50,6 +50,28 @@ module WikidataPositionHistory
       attr_reader :later, :current, :earlier
     end
 
+    # Date for a single output row in a Term-member report
+    class TermMandate
+      extend Forwardable
+
+      def_delegators :mandate, :officeholder, :start_date, :end_date, :party, :district
+
+      def initialize(mandate)
+        @mandate = mandate
+      end
+
+      def dates
+        dates = [start_date, end_date]
+        return '' if dates.compact.empty?
+
+        dates.join(' – ')
+      end
+
+      private
+
+      attr_reader :mandate
+    end
+
     # Base class for the Inception/Abolition date rows
     class PositionDate
       def initialize(metadata)

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -5,6 +5,7 @@ require_relative 'report/legislator'
 require_relative 'report/mandate'
 require_relative 'report/constituency'
 require_relative 'report/position'
+require_relative 'report/term'
 
 module WikidataPositionHistory
   # A list made up of both direct and indirect claims, where we
@@ -115,6 +116,7 @@ module WikidataPositionHistory
       report_class = {
         'legislator'   => Report::Legislator,
         'constituency' => Report::Constituency,
+        'term'         => Report::Term,
       }
       report_class.default = Report::Position
       report_class[metadata.type].new(metadata)

--- a/lib/wikidata_position_history/report/mandate.rb
+++ b/lib/wikidata_position_history/report/mandate.rb
@@ -40,8 +40,12 @@ module WikidataPositionHistory
         biodata_query.new(position_id)
       end
 
+      def mandate_class
+        MandateRow
+      end
+
       def mandates
-        @mandates ||= sparql.results_as(MandateRow)
+        @mandates ||= sparql.results_as(mandate_class)
       end
 
       def no_items_output

--- a/lib/wikidata_position_history/report/mandate.rb
+++ b/lib/wikidata_position_history/report/mandate.rb
@@ -7,7 +7,7 @@ module WikidataPositionHistory
       def wikitext
         return no_items_output if mandates.empty?
 
-        ReportTemplate.new(template_params).output
+        template_class.new(template_params).output
       end
 
       def template_params
@@ -19,6 +19,10 @@ module WikidataPositionHistory
       end
 
       private
+
+      def template_class
+        ReportTemplate::Position
+      end
 
       def biodata
         @biodata ||= biodata_sparql.results_as(BioRow)

--- a/lib/wikidata_position_history/report/term.rb
+++ b/lib/wikidata_position_history/report/term.rb
@@ -8,12 +8,25 @@ module WikidataPositionHistory
         SPARQL::TermMandatesQuery
       end
 
+      def template_class
+        ReportTemplate::Term
+      end
+
       def mandate_class
         TermMandateRow
       end
 
       def biodata_query
         SPARQL::TermBioQuery
+      end
+
+      def table_rows
+        mandates.map do |mandate|
+          {
+            mandate: OutputRow::TermMandate.new(mandate),
+            bio:     biodata_for(mandate.officeholder),
+          }
+        end
       end
     end
   end

--- a/lib/wikidata_position_history/report/term.rb
+++ b/lib/wikidata_position_history/report/term.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module WikidataPositionHistory
+  class Report
+    # Report of representatives during a legislative term
+    class Term < Mandate
+      def mandates_query
+        SPARQL::TermMandatesQuery
+      end
+
+      def mandate_class
+        TermMandateRow
+      end
+
+      def biodata_query
+        SPARQL::TermBioQuery
+      end
+    end
+  end
+end

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -3,91 +3,26 @@
 module WikidataPositionHistory
   # Interface to the ERB Template for the output
   class ReportTemplate
-    def initialize(data)
-      @data = data
-    end
+    # Base class for report templates, to be overriden for each type
+    class Base
+      def initialize(data)
+        @data = data
+      end
 
-    def output
-      template.result_with_hash(data)
-    end
+      def output
+        template.result_with_hash(data)
+      end
 
-    private
+      private
 
-    attr_reader :data
+      attr_reader :data
 
-    def template
-      @template ||= ERB.new(template_text, nil, '-')
-    end
-
-    def template_text
-      <<~ERB
-        {| class="wikitable" style="text-align: center; border: none;"
-        <% if metadata.abolition.date -%>
-        |-
-        | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position abolished''':
-        | style="border: none; background: #fff; text-align: left;" | <%= metadata.abolition.date %>
-        | style="border: none; background: #fff; text-align: left;" | \
-        <% metadata.abolition.warnings.each do |warning| -%>
-        <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
-        <% end %>
-        <% end -%>
-        <% if metadata.successor.position -%>
-        |-
-        | colspan="2" style="border: none; background: #fff; font-size: 1.15em; vertical-align: baseline; text-align: right;" | '''Replaced by''':
-        | style=" border: none; background: #fff; vertical-align: baseline; text-align: left;" | <%= metadata.successor.position %>
-        | style=" border: none; background: #fff; text-align: left;" | \
-        <% metadata.successor.warnings.each do |warning| -%>
-        <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
-        <% end %>
-        <% end -%>
-        <% if metadata.successor.position || metadata.abolition.date -%>
-        |-
-        | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
-        | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
-        <% end -%>
-        <% table_rows.map(&:values).each do |mandate, bio| -%>
-        |-
-        | style="padding:0.5em 2em" | <%= mandate.ordinal_string %>
-        | style="padding:0.5em 2em" | <%= bio.map(&:image_link).first %>
-        | style="padding:0.5em 2em" | <span style="font-size: <%= mandate.acting? ? '1.25em; font-style: italic;' : '1.5em' %>; display: block;"><%= mandate.officeholder.qlink %></span> <%= mandate.dates %>
-        <% if metadata.type == 'constituency' -%>
-        | style="padding:0.5em 1em" | <% if mandate.party %><%= mandate.party.qlink %><% end %>
-        <% end -%>
-        | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
-        <% mandate.warnings.each do |warning| -%>
-        <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
-        <% end %>
-        <% end -%>
-        <% if metadata.successor.position || metadata.abolition.date -%>
-        |-
-        | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
-        | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
-        <% end -%>
-        <% if metadata.inception.date || metadata.inception.warnings.any? -%>
-        |-
-        | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
-        | style="border: none; background: #fff; text-align: left;" | <%= metadata.inception.date %>
-        | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
-        <% metadata.inception.warnings.each do |warning| -%>
-        <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
-        <% end %>
-        <% end -%>
-        <% if metadata.predecessor.position -%>
-        |-
-        | colspan="2" style=" border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaces''':
-        | style="border: none; background: #fff; text-align: left;" | <%= metadata.predecessor.position %>
-        | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
-        <% metadata.predecessor.warnings.each do |warning| -%>
-        <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
-        <% end %>
-        <% end -%>
-        |}
-
-        <div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
-          <div style="float:right">[<%= sparql_url %> WDQS]</div>
-        </div>
-        {{reflist}}
-      ERB
+      def template
+        @template ||= ERB.new(template_text, nil, '-')
+      end
     end
   end
 end
+
+require_relative 'template/position'
+require_relative 'template/term'

--- a/lib/wikidata_position_history/template/position.rb
+++ b/lib/wikidata_position_history/template/position.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module WikidataPositionHistory
+  class ReportTemplate
+    # ERB output template for position and constituency types
+    class Position < Base
+      def template_text
+        <<~ERB
+          {| class="wikitable" style="text-align: center; border: none;"
+          <% if metadata.abolition.date -%>
+          |-
+          | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position abolished''':
+          | style="border: none; background: #fff; text-align: left;" | <%= metadata.abolition.date %>
+          | style="border: none; background: #fff; text-align: left;" | \
+          <% metadata.abolition.warnings.each do |warning| -%>
+          <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
+          <% end %>
+          <% end -%>
+          <% if metadata.successor.position -%>
+          |-
+          | colspan="2" style="border: none; background: #fff; font-size: 1.15em; vertical-align: baseline; text-align: right;" | '''Replaced by''':
+          | style=" border: none; background: #fff; vertical-align: baseline; text-align: left;" | <%= metadata.successor.position %>
+          | style=" border: none; background: #fff; text-align: left;" | \
+          <% metadata.successor.warnings.each do |warning| -%>
+          <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
+          <% end %>
+          <% end -%>
+          <% if metadata.successor.position || metadata.abolition.date -%>
+          |-
+          | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+          | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+          <% end -%>
+          <% table_rows.map(&:values).each do |mandate, bio| -%>
+          |-
+          | style="padding:0.5em 2em" | <%= mandate.ordinal_string %>
+          | style="padding:0.5em 2em" | <%= bio.map(&:image_link).first %>
+          | style="padding:0.5em 2em" | <span style="font-size: <%= mandate.acting? ? '1.25em; font-style: italic;' : '1.5em' %>; display: block;"><%= mandate.officeholder.qlink %></span> <%= mandate.dates %>
+          <% if metadata.type == 'constituency' -%>
+          | style="padding:0.5em 1em" | <% if mandate.party %><%= mandate.party.qlink %><% end %>
+          <% end -%>
+          | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
+          <% mandate.warnings.each do |warning| -%>
+          <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
+          <% end %>
+          <% end -%>
+          <% if metadata.successor.position || metadata.abolition.date -%>
+          |-
+          | colspan="3" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+          | colspan="1" style="padding:0.5em; border: none; background: #fff"> |&nbsp;
+          <% end -%>
+          <% if metadata.inception.date || metadata.inception.warnings.any? -%>
+          |-
+          | colspan="2" style="border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Position created''':
+          | style="border: none; background: #fff; text-align: left;" | <%= metadata.inception.date %>
+          | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
+          <% metadata.inception.warnings.each do |warning| -%>
+          <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
+          <% end %>
+          <% end -%>
+          <% if metadata.predecessor.position -%>
+          |-
+          | colspan="2" style=" border: none; background: #fff; font-size: 1.15em; text-align: right;" | '''Replaces''':
+          | style="border: none; background: #fff; text-align: left;" | <%= metadata.predecessor.position %>
+          | style="padding:0.5em 2em 0.5em 1em; border: none; background: #fff; text-align: left;" | \
+          <% metadata.predecessor.warnings.each do |warning| -%>
+          <span style="display: block">[[File:Pictogram voting comment.svg|15px|link=]]&nbsp;<span style="color: #d33; font-weight: bold; vertical-align: middle;"><%= warning.headline %></span>&nbsp;<ref><%= warning.explanation %></ref></span>\
+          <% end %>
+          <% end -%>
+          |}
+
+          <div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
+            <div style="float:right">[<%= sparql_url %> WDQS]</div>
+          </div>
+          {{reflist}}
+        ERB
+      end
+    end
+  end
+end

--- a/lib/wikidata_position_history/template/term.rb
+++ b/lib/wikidata_position_history/template/term.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module WikidataPositionHistory
+  class ReportTemplate
+    # ERB output template for a Term
+    class Term < Base
+      def template_text
+        <<~ERB
+          {| class="wikitable sortable" style="text-align: center; border: none;"
+          !'''{{P|18}}'''
+          !'''Name'''
+          !'''{{P|4100}}'''
+          !'''{{P|768}}'''
+          |-
+          <% table_rows.map(&:values).each do |mandate, bio| -%>
+          |-
+          | style="padding:0.5em 2em" | <%= bio.map(&:image_link).first %>
+          | style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;"><%= mandate.officeholder.qlink %></span> <%= mandate.dates %>
+          | style="padding:0.5em 1em" | <% if mandate.party %><%= mandate.party.qlink %><% end %>
+          | style="padding:0.5em 1em" | <% if mandate.district %><%= mandate.district.qlink %><% end %>
+          <% end -%>
+          |}
+
+          <div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
+            <div style="float:right">[<%= sparql_url %> WDQS]</div>
+          </div>
+          {{reflist}}
+        ERB
+      end
+    end
+  end
+end

--- a/test/create_example_data.rb
+++ b/test/create_example_data.rb
@@ -11,9 +11,8 @@ def store(id, dir, query)
 end
 
 id = ARGV.first or abort "Usage: #{$PROGRAM_NAME} <Qid>"
-report = WikidataPositionHistory::Report.new(id)
+report = WikidataPositionHistory::Report.new(id).report
 
 store(id, 'metadata', WikidataPositionHistory::SPARQL::PositionQuery.new(id))
-
 store(id, 'mandates', report.send(:sparql))
 store(id, 'biodata', report.send(:biodata_sparql))

--- a/test/example-data/biodata/Q20530392.json
+++ b/test/example-data/biodata/Q20530392.json
@@ -3,6 +3,1364 @@
     "vars" : [ "item", "image" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11023034"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Eenmaa%2C%20Ivi.IMG%200385.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11032994"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Urve%20Tiidus.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11158997"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/IRL%20Sven%20Sester.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11716283"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/IRL%20Margus%20Tsahkna.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11857954"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Enn%20Eesmaa.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11869429"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Kalle%20Palling.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12358062"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Aadu%20Must.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12358429"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Ain%20Lutsepp.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12358481"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Aivar%20S%C3%B5erd.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12360203"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/268%20Barbi%20volikogu%20esindus%202016.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12363563"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Heimar%20Lenk%202006.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12363563"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Heimar%20Lenk.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12364480"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Imre%20Soo%C3%A4%C3%A4r%202012.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12364487"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Inara%20Luigas.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12365130"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/SDE%20Jevgeni%20Ossinovski.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12365796"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/J%C3%BCri%20Adams.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12366157"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/SDE%20Kalev%20Kotkas.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12366158"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Kalev%20Kallo.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12366238"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Muuli%2C%20Kalle.%20by%20Ave%20Maria%20M%C3%B5istlik.IMG%207255.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12366267"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/SDE%20Kalvi%20K%C3%B5va.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12366820"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Kersti%20Sarapuu.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12368739"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/IRL%20Liisa-Ly%20Pakosta.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369791"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Marika%20Tuus.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369838"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Mark%20Soosaar.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369884"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Mart%20Nutt.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369924"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Helme%2C%20Martin.IMG%206116.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369932"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Martin%20Kukk.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369996"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Mati%20Raidma.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12370075"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Meelis%20M%C3%A4lberg.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12370316"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Mihkel%20Raud%2C%202007.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12370928"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Neeme%20Suur%2C%202011.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12371725"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Loone%2C%20Oudekki.IMG%205044.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12372175"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Peeter%20Ernits.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12372781"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Priit%20Toobal.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12372782"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Priit%20Sibul.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12373456"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Rainer%20Vakra.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12373459"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Raivo%20Aeg.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12373774"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Rein%20Ratas.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12373839"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Remo%20Holsmer.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12375092"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Siret%20Kotka.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12376325"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Tanel%20Talve.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12376376"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Tarmo%20Tamm.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12376941"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Tiit%20Terik%202013.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12377090"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Toomas%20Kivim%C3%A4gi.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12378637"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Viktor%20Vassiljev.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12379326"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Yana%20Toom.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13234758"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/SDE%20Andres%20Anvelt.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13570003"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Kadri%20Simson%202017-05-25%20%28cropped%29.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13607430"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Urmas%20Klaas.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13608089"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/IRL%20Aivar%20Kokk.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13628736"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/SDE%20Helmen%20K%C3%BCtt.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13629005"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Lauri%20Laasi.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1385792"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Ken-Marti%20Vaher%2C%202011.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1398025"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Ivari%20Padar%20at%20Laulupidu%20cropped.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1399189"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/IRL%20Marko%20Pomerants.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1399218"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Hanno%20Pevkur%2C%202011.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1410118"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Jaanus%20Marrandi.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14191221"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Lauri%20Luik.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14483307"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/SDE%20Heljo%20Pikhof.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1453245"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Mart%20Helme.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14542629"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/SDE%20Rein%20Randver.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15983657"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Anne%20Sulling%20in%20October%2027%2C%202014.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16402978"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Johannes%20Kert.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16403371"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/SDE%20Indrek%20Saar.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16403439"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16403802"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Madis%20Milling.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404003"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Sarapuu%2C%20Arvo.IMG%205545.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404020"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Korb%2C%20Mihhail.IMG%202249.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404281"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Krista%20Aru.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404443"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Tsahkna-Kruusim%C3%A4e.IMG%201059.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404493"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Heidy%20Purga.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404500"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Andre%20Sepp.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405090"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Henn%20P%C3%B5lluaas.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405149"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Novikov%2C%20Andrei.IMG%202287.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405217"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20K%C3%BClliki%20K%C3%BCbarsepp.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405450"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Viktoria%20Lad%C3%B5nskaja.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405534"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405538"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20M%C3%A4rt%20Sults.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405768"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Maris%20Lauri.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16406074"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Artur%20Talvik.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16406537"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Olga%20Ivanova.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16407309"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Terje%20Trei.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16407380"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Maatee%20Aet.IMG%202928.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16407871"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17446896"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Alender%2C%20Yoko.IMG%202599.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17446918"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Hannes%20Hanso.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17447338"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Einar%20Vallbaum.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1789192"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Kristen%20Michal.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1900847"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/IRL%20Marko%20Mihkelson.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19725706"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Jaak%20Madison.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2000385"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Deniss%20Borodit%C5%A1.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20528288"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20528341"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Uno%20Kaskpeit.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20528366"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Andres%20Ammas.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20528493"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Erki%20Savisaar.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20528676"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Monika%20Haukan%C3%B5mm.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2067037"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Peep%20Aru.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933454"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Arno%20Sild.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933467"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Dmitri%20Dmitrijev.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933507"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Jaanus%20Karilaid.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933509"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Liina%20Kersna.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933524"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Kristjan%20K%C3%B5ljalg.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933540"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Andres%20Metsoja.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933554"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Raivo%20P%C3%B5ldaru.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933560"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Martin%20Repinski.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2097451"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Sven%20Mikser%202017-05-25.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21009735"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Tenth%20WTO%20Ministerial%20Conference%20-%20Day%203%20-%20Plenary%20session%20%2823197532274%29.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2128576"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Rait%20Maruste.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q22041600"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285186"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Baltijas%20Asamblejas%2038.sesija%20%2849140855051%29.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q253515"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Jaak%20Aaviksoo%2C%202011.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q25519722"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2621730"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/J%C3%BCri%20Ratas%202017-05.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28071323"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28071329"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28840779"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28845703"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28854341"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28854356"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28854358"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q312894"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Juhan-Parts.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q312894"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Juhan%20Parts.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q355241"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Edgar%20Savisaar.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3735691"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Kross%2C%20Eerik-Niiles.IMG%202106.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3736458"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Ants%20Laaneots.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3740790"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Hardivolmerhirvepargis.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3741429"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Tartu%20linnapea%20Urmas%20Kruuse%20Tartu%20hansalaadal%2C%2020.%20juuli%202008-crop.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3741812"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Mihhail%20Stalnuhhin.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3741900"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Vladimir%20Velman.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3785077"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Taavi%20R%C3%B5ivas.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3785077"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Taavi%20R%C3%B5ivas.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4232659"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Valeri%20Korb.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4250802"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Mihhail-Kolvart.JPG"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q449851"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Mailis%20Reps%202017-05-25.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q449939"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Laine%20Randj%C3%A4rv.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q450523"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/SDE%20Eiki%20Nestor.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q458003"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Keit%20Pentus-Rosimannus%20%289787050155%29%20%28cropped%29.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q458003"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Keit%20Pentus%2C%202011.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q460589"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Vilja%20Savisaar-Toomast.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q465437"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/SDE%20Urve%20Palo.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4756115"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/IRL%20Andres%20Herkel.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q535290"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/SDE%20Marianne%20Mikko.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q53636801"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q53638402"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q55984168"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5993313"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Igor%20Gr%C3%A4zin.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q616356"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Arto%20Aas.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q645970"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Urmas%20Reinsalu%202017-05-25%20%28cropped%29.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6736905"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Maire%20Aunaste.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q704436"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20J%C3%BCri%20Jaanson.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q724437"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Helir-Valdor%20Seeder%2C%202011.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q743341"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Siim-Valmar%20Kiisler.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7824120"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RK%20Toomas%20Vitsut.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q788525"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Paul-Eerik%20Rummo.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7909441"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/RE%20Valdo%20Randpere.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q978349"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/KE%20Kalle%20Laanet.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q983831"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/J%C3%BCrgen%20Ligi%2C%202011.jpg"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q58100"
+      },
+      "image" : {
+        "type" : "uri",
+        "value" : "http://commons.wikimedia.org/wiki/Special:FilePath/Urmas%20Paet.jpg"
+      }
+    } ]
   }
 }

--- a/test/example-data/mandates/Q20530392.json
+++ b/test/example-data/mandates/Q20530392.json
@@ -1,8 +1,5103 @@
 {
   "head" : {
-    "vars" : [ "ordinal", "item", "start_date", "start_precision", "end_date", "end_precision", "prev", "next", "nature" ]
+    "vars" : [ "item", "start_date", "start_precision", "end_date", "end_precision", "prev", "next", "party", "district", "endCause" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11032994"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2972997"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11158997"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11716283"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11857954"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2972997"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11869429"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12358062"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12358429"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19276353"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12358481"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12363563"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12365130"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3479058"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-14T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12365796"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19276353"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12366158"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12366267"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12366820"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369791"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3338787"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369924"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q794028"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369932"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-07-06T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12370316"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-06-07T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12372781"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-11-18T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q22041600"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12372782"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12373456"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12373459"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2972997"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12373774"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-05T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12373839"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-05-06T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12375092"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3485728"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12376325"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3338787"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12376376"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-10T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12377090"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3038253"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12378637"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12379326"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3479058"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-27T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13234758"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13570003"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3038253"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13607430"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-27T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13608089"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3338787"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13628736"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13629005"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-11-20T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1385792"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-01T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1398025"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-11-07T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14542629"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1399189"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3485728"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1399218"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1410118"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14191221"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2972997"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14483307"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1453245"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q794028"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3038253"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15983657"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16402978"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16403371"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3485728"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16403802"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404020"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404281"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19276353"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404493"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405090"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q794028"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405149"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-11-10T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405217"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19276353"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2019-01-11T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16403439"
+      },
+      "endCause" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21008813"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405450"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405538"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405768"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-09-12T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16406074"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19276353"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16406537"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16407309"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3338787"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17446896"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17446918"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2972997"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-14T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1789192"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1900847"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19725706"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q794028"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2000385"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3479058"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-08-01T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q55984168"
+      },
+      "endCause" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q796919"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20528341"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q794028"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20528366"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19276353"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2972997"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-04-04T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q53636801"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20528493"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20528676"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19276353"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933454"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q794028"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933467"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3479058"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933509"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933540"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3038253"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933554"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q794028"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3338787"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933560"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3479058"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2097451"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q253515"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-08-31T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2621730"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q312894"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-15T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q355241"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q327591"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-08-05T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3735691"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-06-15T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q460589"
+      },
+      "endCause" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q796919"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3736458"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3741429"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3338787"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3741812"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3479058"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3741900"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3785077"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4232659"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3479058"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4250802"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-27T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q449851"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q449939"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2019-02-05T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285186"
+      },
+      "endCause" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q796919"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q450523"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q458003"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q465437"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4756115"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19276353"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5993313"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3338787"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-09-05T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369996"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q616356"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q645970"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6736905"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q704436"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3038253"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q724437"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7824120"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q7909441"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3485728"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q978349"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2972997"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q983831"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-08T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q58100"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-30T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-03-27T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11023034"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-07-15T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q458003"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12364480"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12366238"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-12T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11716283"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369838"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3038253"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-24T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16403371"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369884"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q645970"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369996"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3338787"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3741429"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12370075"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404500"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17447338"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3485728"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-12T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1399189"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1399189"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933524"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3740790"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-14T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2097451"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q460589"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1789192"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q535290"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-09T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-14T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q465437"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933507"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-04-27T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2972997"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q458003"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-07-16T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12372175"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-08-18T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q743341"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-01T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-12T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12370928"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-15T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2972997"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-16T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405534"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-15T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-16T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2097451"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-15T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q465437"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-15T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12366157"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-16T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2972997"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q535290"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-09-16T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12370928"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q22041600"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-11-19T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12372781"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12371725"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2015-11-21T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q25519722"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-06-16T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2067037"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-07-07T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2128576"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-09-13T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1399218"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405768"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q17446918"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2972997"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1789192"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28854358"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-24T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3741429"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3338787"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3785077"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q616356"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q983831"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-23T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12360203"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-24T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-11-26T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13234758"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12376941"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-24T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16407380"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-24T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-25T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16407871"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-24T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21009735"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-24T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-08-22T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q465437"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28071329"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-24T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3038253"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-12T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28854341"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-24T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3485728"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28854356"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-24T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-09T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3740790"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-24T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12364487"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-11-25T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404003"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-05T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-06T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28840779"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-06T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2420663"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12373774"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933560"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-10T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3479058"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-06-26T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28854356"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28845703"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-10T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-11T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12376376"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28071323"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-11T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3352911"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20528288"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-12-16T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12368739"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-01T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-02T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404443"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-02T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11158997"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-12T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11716283"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-12T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3032626"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1399189"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-12T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q163347"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3485728"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16404020"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-06-12T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14542629"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-11-08T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-05-02T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1398025"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12365130"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q53638402"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2017-11-10T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3402163"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405149"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q53636801"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-04-05T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19276353"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2972997"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20528366"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12365130"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-05-03T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3479058"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14542629"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2067037"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-05-07T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3142965"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q460589"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-06-15T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3735691"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q28854356"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-06-28T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928652"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20933560"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q55984168"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-08-01T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3479058"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2000385"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q465437"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-08-22T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3413626"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21009735"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12369996"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-09-05T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q5993313"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13234758"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-11-26T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-11-27T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12360203"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12360203"
+      },
+      "endCause" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q796919"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q12360203"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-11-27T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q913551"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q13234758"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16403439"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2019-01-11T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q19276353"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16405217"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285186"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2019-02-05T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2019-02-06T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q449939"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q788525"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q788525"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2019-02-06T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "end_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2019-02-07T00:00:00Z"
+      },
+      "end_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285186"
+      },
+      "next" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11023034"
+      }
+    }, {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11023034"
+      },
+      "start_date" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2019-02-07T00:00:00Z"
+      },
+      "start_precision" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+        "type" : "literal",
+        "value" : "11"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q3025278"
+      },
+      "prev" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q788525"
+      }
+    } ]
   }
 }

--- a/test/example-data/metadata/Q20530392.json
+++ b/test/example-data/metadata/Q20530392.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isConstituency", "representative_count", "legislature" ]
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isTerm", "isConstituency", "representative_count", "legislature" ]
   },
   "results" : {
     "bindings" : [ {
@@ -37,6 +37,11 @@
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
         "type" : "literal",
         "value" : "false"
+      },
+      "isTerm" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
       },
       "isConstituency" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",

--- a/test/expected-output/Q20530392.out
+++ b/test/expected-output/Q20530392.out
@@ -1,0 +1,917 @@
+{| class="wikitable sortable" style="text-align: center; border: none;"
+!'''{{P|18}}'''
+!'''Name'''
+!'''{{P|4100}}'''
+!'''{{P|768}}'''
+|-
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Urve%20Tiidus.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q11032994}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q2972997}}
+|-
+| style="padding:0.5em 2em" | [[File:IRL%20Sven%20Sester.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q11158997}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:IRL%20Margus%20Tsahkna.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q11716283}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Enn%20Eesmaa.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q11857954}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q2972997}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Kalle%20Palling.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q11869429}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:Aadu%20Must.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12358062}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Ain%20Lutsepp.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12358429}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q19276353}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Aivar%20S%C3%B5erd.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12358481}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:Heimar%20Lenk%202006.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12363563}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Jevgeni%20Ossinovski.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12365130}}</span> 2015-03-30 – 2015-09-14
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3479058}}
+|-
+| style="padding:0.5em 2em" | [[File:J%C3%BCri%20Adams.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12365796}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q19276353}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Kalev%20Kallo.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12366158}}</span> 2015-03-30 – 2015-04-23
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Kalvi%20K%C3%B5va.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12366267}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Kersti%20Sarapuu.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12366820}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Marika%20Tuus.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12369791}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3338787}}
+|-
+| style="padding:0.5em 2em" | [[File:Helme%2C%20Martin.IMG%206116.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12369924}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q794028}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Martin%20Kukk.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12369932}}</span> 2015-03-30 – 2016-07-06
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:Mihkel%20Raud%2C%202007.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12370316}}</span> 2015-03-30 – 2016-06-07
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Priit%20Toobal.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12372781}}</span> 2015-03-30 – 2015-11-18
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Priit%20Sibul.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12372782}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Rainer%20Vakra.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12373456}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Raivo%20Aeg.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12373459}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q2972997}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Rein%20Ratas.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12373774}}</span> 2015-03-30 – 2016-12-05
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Remo%20Holsmer.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12373839}}</span> 2015-03-30 – 2018-05-06
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Siret%20Kotka.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12375092}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3485728}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Tanel%20Talve.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12376325}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3338787}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Tarmo%20Tamm.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12376376}}</span> 2015-03-30 – 2016-12-10
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Toomas%20Kivim%C3%A4gi.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12377090}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3038253}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Viktor%20Vassiljev.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12378637}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Yana%20Toom.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12379326}}</span> 2015-03-30 – 2015-03-27
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3479058}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Andres%20Anvelt.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q13234758}}</span> 2015-03-30 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:Kadri%20Simson%202017-05-25%20%28cropped%29.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q13570003}}</span> 2015-03-30 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3038253}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Urmas%20Klaas.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q13607430}}</span> 2015-03-30 – 2015-03-27
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:IRL%20Aivar%20Kokk.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q13608089}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3338787}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Helmen%20K%C3%BCtt.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q13628736}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Lauri%20Laasi.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q13629005}}</span> 2015-03-30 – 2015-11-20
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:Ken-Marti%20Vaher%2C%202011.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1385792}}</span> 2015-03-30 – 2017-06-01
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:Ivari%20Padar%20at%20Laulupidu%20cropped.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1398025}}</span> 2015-03-30 – 2017-11-07
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:IRL%20Marko%20Pomerants.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1399189}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3485728}}
+|-
+| style="padding:0.5em 2em" | [[File:Hanno%20Pevkur%2C%202011.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1399218}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Jaanus%20Marrandi.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1410118}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Lauri%20Luik.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q14191221}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q2972997}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Heljo%20Pikhof.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q14483307}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:Mart%20Helme.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1453245}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q794028}}
+| style="padding:0.5em 1em" | {{Q|Q3038253}}
+|-
+| style="padding:0.5em 2em" | [[File:Anne%20Sulling%20in%20October%2027%2C%202014.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q15983657}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Johannes%20Kert.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16402978}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Indrek%20Saar.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16403371}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3485728}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Madis%20Milling.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16403802}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:Korb%2C%20Mihhail.IMG%202249.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16404020}}</span> 2015-03-30 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:Krista%20Aru.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16404281}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q19276353}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Heidy%20Purga.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16404493}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Henn%20P%C3%B5lluaas.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16405090}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q794028}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:Novikov%2C%20Andrei.IMG%202287.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16405149}}</span> 2015-03-30 – 2017-11-10
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20K%C3%BClliki%20K%C3%BCbarsepp.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16405217}}</span> 2015-03-30 – 2019-01-11
+| style="padding:0.5em 1em" | {{Q|Q19276353}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Viktoria%20Lad%C3%B5nskaja.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16405450}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20M%C3%A4rt%20Sults.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16405538}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Maris%20Lauri.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16405768}}</span> 2015-03-30 – 2016-09-12
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Artur%20Talvik.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16406074}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q19276353}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Olga%20Ivanova.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16406537}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Terje%20Trei.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16407309}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3338787}}
+|-
+| style="padding:0.5em 2em" | [[File:Alender%2C%20Yoko.IMG%202599.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q17446896}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Hannes%20Hanso.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q17446918}}</span> 2015-03-30 – 2015-09-14
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q2972997}}
+|-
+| style="padding:0.5em 2em" | [[File:Kristen%20Michal.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1789192}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:IRL%20Marko%20Mihkelson.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1900847}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Jaak%20Madison.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q19725706}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q794028}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Deniss%20Borodit%C5%A1.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q2000385}}</span> 2015-03-30 – 2018-08-01
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3479058}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Uno%20Kaskpeit.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20528341}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q794028}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Andres%20Ammas.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20528366}}</span> 2015-03-30 – 2018-04-04
+| style="padding:0.5em 1em" | {{Q|Q19276353}}
+| style="padding:0.5em 1em" | {{Q|Q2972997}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Erki%20Savisaar.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20528493}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Monika%20Haukan%C3%B5mm.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20528676}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q19276353}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Arno%20Sild.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20933454}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q794028}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Dmitri%20Dmitrijev.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20933467}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3479058}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Liina%20Kersna.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20933509}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Andres%20Metsoja.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20933540}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3038253}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Raivo%20P%C3%B5ldaru.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20933554}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q794028}}
+| style="padding:0.5em 1em" | {{Q|Q3338787}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Martin%20Repinski.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20933560}}</span> 2015-03-30 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3479058}}
+|-
+| style="padding:0.5em 2em" | [[File:Sven%20Mikser%202017-05-25.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q2097451}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:Jaak%20Aaviksoo%2C%202011.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q253515}}</span> 2015-03-30 – 2015-08-31
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:J%C3%BCri%20Ratas%202017-05.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q2621730}}</span> 2015-03-30 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:Juhan-Parts.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q312894}}</span> 2015-03-30 – 2016-12-15
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Edgar%20Savisaar.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q355241}}</span> 2015-03-30 – 2015-08-05
+| style="padding:0.5em 1em" | {{Q|Q327591}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:Kross%2C%20Eerik-Niiles.IMG%202106.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q3735691}}</span> 2015-03-30 – 2018-06-15
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Ants%20Laaneots.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q3736458}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:Tartu%20linnapea%20Urmas%20Kruuse%20Tartu%20hansalaadal%2C%2020.%20juuli%202008-crop.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q3741429}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3338787}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Mihhail%20Stalnuhhin.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q3741812}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3479058}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Vladimir%20Velman.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q3741900}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Taavi%20R%C3%B5ivas.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q3785077}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Valeri%20Korb.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q4232659}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3479058}}
+|-
+| style="padding:0.5em 2em" | [[File:Mihhail-Kolvart.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q4250802}}</span> 2015-03-30 – 2015-03-27
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:Mailis%20Reps%202017-05-25.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q449851}}</span> 2015-03-30 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Laine%20Randj%C3%A4rv.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q449939}}</span> 2015-03-30 – 2019-02-05
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Eiki%20Nestor.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q450523}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:Keit%20Pentus-Rosimannus%20%289787050155%29%20%28cropped%29.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q458003}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Urve%20Palo.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q465437}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:IRL%20Andres%20Herkel.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q4756115}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q19276353}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Igor%20Gr%C3%A4zin.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q5993313}}</span> 2015-03-30 – 2018-09-05
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3338787}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Arto%20Aas.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q616356}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:Urmas%20Reinsalu%202017-05-25%20%28cropped%29.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q645970}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Maire%20Aunaste.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q6736905}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20J%C3%BCri%20Jaanson.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q704436}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3038253}}
+|-
+| style="padding:0.5em 2em" | [[File:Helir-Valdor%20Seeder%2C%202011.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q724437}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Toomas%20Vitsut.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q7824120}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Valdo%20Randpere.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q7909441}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3485728}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Kalle%20Laanet.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q978349}}</span> 2015-03-30 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q2972997}}
+|-
+| style="padding:0.5em 2em" | [[File:J%C3%BCrgen%20Ligi%2C%202011.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q983831}}</span> 2015-03-30 – 2015-04-08
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:Urmas%20Paet.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q58100}}</span> 2015-03-30 – 2015-03-27
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:Eenmaa%2C%20Ivi.IMG%200385.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q11023034}}</span> 2015-04-09 – 2015-07-15
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:Imre%20Soo%C3%A4%C3%A4r%202012.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12364480}}</span> 2015-04-09 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:Muuli%2C%20Kalle.%20by%20Ave%20Maria%20M%C3%B5istlik.IMG%207255.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12366238}}</span> 2015-04-09 – 2017-06-12
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:Mark%20Soosaar.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12369838}}</span> 2015-04-09 – 2016-11-24
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3038253}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Mart%20Nutt.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12369884}}</span> 2015-04-09 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Mati%20Raidma.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12369996}}</span> 2015-04-09 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3338787}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Meelis%20M%C3%A4lberg.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12370075}}</span> 2015-04-09 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Andre%20Sepp.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16404500}}</span> 2015-04-09 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Einar%20Vallbaum.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q17447338}}</span> 2015-04-09 – 2017-06-12
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3485728}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Kristjan%20K%C3%B5ljalg.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20933524}}</span> 2015-04-09 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:Hardivolmerhirvepargis.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q3740790}}</span> 2015-04-09 – 2015-09-14
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Vilja%20Savisaar-Toomast.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q460589}}</span> 2015-04-09 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Marianne%20Mikko.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q535290}}</span> 2015-04-09 – 2015-09-14
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Jaanus%20Karilaid.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20933507}}</span> 2015-04-27 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q2972997}}
+|-
+| style="padding:0.5em 2em" | [[File:Keit%20Pentus-Rosimannus%20%289787050155%29%20%28cropped%29.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q458003}}</span> 2015-07-16 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Peeter%20Ernits.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12372175}}</span> 2015-08-18 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:Siim-Valmar%20Kiisler.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q743341}}</span> 2015-09-01 – 2017-06-12
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:Neeme%20Suur%2C%202011.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12370928}}</span> 2015-09-15 – 2015-09-16
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q2972997}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16405534}}</span> 2015-09-15 – 2015-09-16
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | 
+|-
+| style="padding:0.5em 2em" | [[File:Sven%20Mikser%202017-05-25.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q2097451}}</span> 2015-09-15 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Urve%20Palo.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q465437}}</span> 2015-09-15 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Kalev%20Kotkas.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12366157}}</span> 2015-09-16 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q2972997}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Marianne%20Mikko.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q535290}}</span> 2015-09-16 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q22041600}}</span> 2015-11-19 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:Loone%2C%20Oudekki.IMG%205044.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12371725}}</span> 2015-11-21 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q25519722}}</span> 2016-06-16 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Peep%20Aru.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q2067037}}</span> 2016-07-07 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Rait%20Maruste.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q2128576}}</span> 2016-09-13 – 2016-11-23
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:Hanno%20Pevkur%2C%202011.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1399218}}</span> 2016-11-23 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Maris%20Lauri.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16405768}}</span> 2016-11-23 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Hannes%20Hanso.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q17446918}}</span> 2016-11-23 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q2972997}}
+|-
+| style="padding:0.5em 2em" | [[File:Kristen%20Michal.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1789192}}</span> 2016-11-23 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q28854358}}</span> 2016-11-23 – 2016-11-24
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | 
+|-
+| style="padding:0.5em 2em" | [[File:Tartu%20linnapea%20Urmas%20Kruuse%20Tartu%20hansalaadal%2C%2020.%20juuli%202008-crop.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q3741429}}</span> 2016-11-23 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3338787}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Taavi%20R%C3%B5ivas.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q3785077}}</span> 2016-11-23 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Arto%20Aas.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q616356}}</span> 2016-11-23 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:J%C3%BCrgen%20Ligi%2C%202011.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q983831}}</span> 2016-11-23 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:268%20Barbi%20volikogu%20esindus%202016.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12360203}}</span> 2016-11-24 – 2018-11-26
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:Tiit%20Terik%202013.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12376941}}</span> 2016-11-24 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:Maatee%20Aet.IMG%202928.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16407380}}</span> 2016-11-24 – 2016-11-25
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16407871}}</span> 2016-11-24 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:Tenth%20WTO%20Ministerial%20Conference%20-%20Day%203%20-%20Plenary%20session%20%2823197532274%29.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q21009735}}</span> 2016-11-24 – 2018-08-22
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q28071329}}</span> 2016-11-24 – 2017-06-12
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3038253}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q28854341}}</span> 2016-11-24 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3485728}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q28854356}}</span> 2016-11-24 – 2016-12-09
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | 
+|-
+| style="padding:0.5em 2em" | [[File:Hardivolmerhirvepargis.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q3740790}}</span> 2016-11-24 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:KE%20Inara%20Luigas.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12364487}}</span> 2016-11-25 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | [[File:Sarapuu%2C%20Arvo.IMG%205545.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16404003}}</span> 2016-12-05 – 2016-12-06
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q28840779}}</span> 2016-12-06 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q2420663}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Martin%20Repinski.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20933560}}</span> 2016-12-10 – 2018-06-26
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3479058}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q28845703}}</span> 2016-12-10 – 2016-12-11
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q28071323}}</span> 2016-12-11 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3352911}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q20528288}}</span> 2016-12-16 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:IRL%20Liisa-Ly%20Pakosta.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12368739}}</span> 2017-06-01 – 2017-06-02
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | 
+|-
+| style="padding:0.5em 2em" | [[File:Tsahkna-Kruusim%C3%A4e.IMG%201059.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16404443}}</span> 2017-06-02 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | [[File:IRL%20Sven%20Sester.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q11158997}}</span> 2017-06-12 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:IRL%20Margus%20Tsahkna.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q11716283}}</span> 2017-06-12 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3032626}}
+|-
+| style="padding:0.5em 2em" | [[File:IRL%20Marko%20Pomerants.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q1399189}}</span> 2017-06-12 – 
+| style="padding:0.5em 1em" | {{Q|Q163347}}
+| style="padding:0.5em 1em" | {{Q|Q3485728}}
+|-
+| style="padding:0.5em 2em" | [[File:Korb%2C%20Mihhail.IMG%202249.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16404020}}</span> 2017-06-12 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Rein%20Randver.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q14542629}}</span> 2017-11-08 – 2018-05-02
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q53638402}}</span> 2017-11-10 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | {{Q|Q3402163}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q53636801}}</span> 2018-04-05 – 
+| style="padding:0.5em 1em" | {{Q|Q19276353}}
+| style="padding:0.5em 1em" | {{Q|Q2972997}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Jevgeni%20Ossinovski.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12365130}}</span> 2018-05-03 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3479058}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Peep%20Aru.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q2067037}}</span> 2018-05-07 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3142965}}
+|-
+| style="padding:0.5em 2em" | [[File:RK%20Vilja%20Savisaar-Toomast.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q460589}}</span> 2018-06-15 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q28854356}}</span> 2018-06-28 – 
+| style="padding:0.5em 1em" | {{Q|Q928652}}
+| style="padding:0.5em 1em" | 
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q55984168}}</span> 2018-08-01 – 
+| style="padding:0.5em 1em" | 
+| style="padding:0.5em 1em" | {{Q|Q3479058}}
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Urve%20Palo.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q465437}}</span> 2018-08-22 – 
+| style="padding:0.5em 1em" | 
+| style="padding:0.5em 1em" | {{Q|Q3413626}}
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Mati%20Raidma.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12369996}}</span> 2018-09-05 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | 
+|-
+| style="padding:0.5em 2em" | [[File:SDE%20Andres%20Anvelt.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q13234758}}</span> 2018-11-26 – 2018-11-27
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | [[File:268%20Barbi%20volikogu%20esindus%202016.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q12360203}}</span> 2018-11-27 – 
+| style="padding:0.5em 1em" | {{Q|Q913551}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|-
+| style="padding:0.5em 2em" | 
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q16403439}}</span> 2019-01-11 – 
+| style="padding:0.5em 1em" | {{Q|Q19276353}}
+| style="padding:0.5em 1em" | 
+|-
+| style="padding:0.5em 2em" | [[File:Baltijas%20Asamblejas%2038.sesija%20%2849140855051%29.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q2285186}}</span> 2019-02-05 – 2019-02-06
+| style="padding:0.5em 1em" | 
+| style="padding:0.5em 1em" | 
+|-
+| style="padding:0.5em 2em" | [[File:RE%20Paul-Eerik%20Rummo.jpg|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q788525}}</span> 2019-02-06 – 2019-02-07
+| style="padding:0.5em 1em" | 
+| style="padding:0.5em 1em" | 
+|-
+| style="padding:0.5em 2em" | [[File:Eenmaa%2C%20Ivi.IMG%200385.JPG|75px]]
+| style="padding:0.5em 2em" | <span style="font-size: 1.5em; display: block;">{{Q|Q11023034}}</span> 2019-02-07 – 
+| style="padding:0.5em 1em" | {{Q|Q738947}}
+| style="padding:0.5em 1em" | {{Q|Q3025278}}
+|}
+
+<div style="margin-bottom:5px; border-bottom:3px solid #2f74d0; font-size:8pt">
+  <div style="float:right">[https://query.wikidata.org/#%23%20term-mandates%0A%0ASELECT%20DISTINCT%20%3Fitem%20%3Fstart_date%20%3Fstart_precision%20%3Fend_date%20%3Fend_precision%20%3Fprev%20%3Fnext%20%3Fparty%20%3Fdistrict%20%3FendCause%0AWHERE%20%7B%0A%20%20%3Fitem%20wdt%3AP31%20wd%3AQ5%20%3B%20p%3AP39%20%3Fposn%20.%0A%20%20%3Fposn%20ps%3AP39%20%3Fposition%20.%0A%20%20%3Fposn%20pq%3AP2937%20wd%3AQ20530392%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20%3Fposn%20wikibase%3Arank%20wikibase%3ADeprecatedRank%20%7D%0A%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP580%20%5B%20wikibase%3AtimeValue%20%3Fstart_date%3B%20wikibase%3AtimePrecision%20%3Fstart_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pqv%3AP582%20%5B%20wikibase%3AtimeValue%20%3Fend_date%3B%20wikibase%3AtimePrecision%20%3Fend_precision%20%5D%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1365%7Cpq%3AP155%20%3Fprev%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1366%7Cpq%3AP156%20%3Fnext%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP4100%20%3Fparty%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP768%20%3Fdistrict%20%7D%0A%20%20OPTIONAL%20%7B%20%3Fposn%20pq%3AP1534%20%3FendCause%20%7D%0A%7D%0AORDER%20BY%20%3Fstart_date%20%3Fitem%0A WDQS]</div>
+</div>
+{{reflist}}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,6 +47,13 @@ def stub_constituency_mandate_query
   end
 end
 
+def stub_term_mandate_query
+  stub_request(:get, %r{query.wikidata.org/sparql.*term-mandates}).to_return do |request|
+    filename = request.uri.to_s[/pq:P2937%20wd:(Q\d+)/, 1]
+    { body: (cached_mandates_path + filename).sub_ext('.json').read }
+  end
+end
+
 def stub_metadata_query
   stub_request(:get, %r{query.wikidata.org/sparql.*position-metadata}).to_return do |request|
     filename = request.uri.to_s[/wd:(Q\d+)/, 1]
@@ -68,10 +75,19 @@ def stub_constituency_biodata_query
   end
 end
 
+def stub_term_biodata_query
+  stub_request(:get, %r{query.wikidata.org/sparql.*term-biodata}).to_return do |request|
+    filename = request.uri.to_s[/pq:P2937%20wd:(Q\d+)/, 1]
+    { body: (cached_biodata_path + filename).sub_ext('.json').read }
+  end
+end
+
 def use_sample_data
   stub_mandate_query
   stub_constituency_mandate_query
+  stub_term_mandate_query
   stub_metadata_query
   stub_biodata_query
   stub_constituency_biodata_query
+  stub_term_biodata_query
 end

--- a/test/wikidata_position_history/report/position_metadata_spec.rb
+++ b/test/wikidata_position_history/report/position_metadata_spec.rb
@@ -82,6 +82,6 @@ describe WikidataPositionHistory::Report do
   describe 'legislative term' do
     let(:position_id) { 'Q20530392' }
 
-    it { expect(metadata.type).must_be_nil }
+    it { expect(metadata.type).must_equal 'term' }
   end
 end

--- a/test/wikidata_position_history/report/wikitext_spec.rb
+++ b/test/wikidata_position_history/report/wikitext_spec.rb
@@ -64,4 +64,10 @@ describe WikidataPositionHistory::Report do
 
     it { expect(report.wikitext).must_equal expected }
   end
+
+  describe '13th Estonian Riigikogu' do
+    let(:id) { 'Q20530392' }
+
+    it { expect(report.wikitext).must_equal expected }
+  end
 end


### PR DESCRIPTION
If given a legislative term, list everyone who was a member during that
term. For now this simply looks for a relevant term qualifier: later it can
be expanded to look for everyone who was a member between the dates of the
term.

![Screenshot 2020-10-14 at 18 36 54](https://user-images.githubusercontent.com/57483/96024893-4d2c8a00-0e4c-11eb-87c5-2204e75b4464.png)
