### PR TITLE
[refactoring] add magic __ITEMID__ variable to SPARQL

### DIFF
--- a/lib/sparql/bio_query.rb
+++ b/lib/sparql/bio_query.rb
@@ -14,7 +14,7 @@ module WikidataPositionHistory
 
           SELECT DISTINCT ?item ?image
           WHERE {
-            ?item wdt:P31 wd:Q5 ; p:P39/ps:P39 wd:%s .
+            ?item wdt:P31 wd:Q5 ; p:P39/ps:P39 wd:__ITEMID__ .
             OPTIONAL { ?item wdt:P18 ?image }
           }
           ORDER BY ?item
@@ -30,7 +30,7 @@ module WikidataPositionHistory
 
           SELECT DISTINCT ?item ?image
           WHERE {
-            ?item wdt:P31 wd:Q5 ; p:P39/pq:P768 wd:%s .
+            ?item wdt:P31 wd:Q5 ; p:P39/pq:P768 wd:__ITEMID__ .
             OPTIONAL { ?item wdt:P18 ?image }
           }
           ORDER BY ?item
@@ -46,7 +46,7 @@ module WikidataPositionHistory
 
           SELECT DISTINCT ?item ?image
           WHERE {
-            ?item wdt:P31 wd:Q5 ; p:P39/pq:P2937 wd:%s .
+            ?item wdt:P31 wd:Q5 ; p:P39/pq:P2937 wd:__ITEMID__ .
             OPTIONAL { ?item wdt:P18 ?image }
           }
           ORDER BY ?item

--- a/lib/sparql/item_query.rb
+++ b/lib/sparql/item_query.rb
@@ -23,11 +23,7 @@ module WikidataPositionHistory
       attr_reader :itemid
 
       def sparql
-        raw_sparql % sparql_args
-      end
-
-      def sparql_args
-        itemid
+        raw_sparql.gsub('__ITEMID__', itemid)
       end
 
       def json

--- a/lib/sparql/mandates_query.rb
+++ b/lib/sparql/mandates_query.rb
@@ -11,7 +11,7 @@ module WikidataPositionHistory
           SELECT DISTINCT ?ordinal ?item ?start_date ?start_precision ?end_date ?end_precision ?prev ?next ?nature
           WHERE {
             ?item wdt:P31 wd:Q5 ; p:P39 ?posn .
-            ?posn ps:P39 wd:%s .
+            ?posn ps:P39 wd:__ITEMID__ .
             FILTER NOT EXISTS { ?posn wikibase:rank wikibase:DeprecatedRank }
 
             OPTIONAL { ?posn pqv:P580 [ wikibase:timeValue ?start_date; wikibase:timePrecision ?start_precision ] }
@@ -35,7 +35,7 @@ module WikidataPositionHistory
           SELECT DISTINCT ?ordinal ?item ?start_date ?start_precision ?end_date ?end_precision ?party ?prev ?next ?term
           WHERE {
             ?item wdt:P31 wd:Q5 ; p:P39 ?posn .
-            ?posn pq:P768 wd:%s .
+            ?posn pq:P768 wd:__ITEMID__ .
             FILTER NOT EXISTS { ?posn wikibase:rank wikibase:DeprecatedRank }
 
             OPTIONAL { ?posn pqv:P580 [ wikibase:timeValue ?start_date; wikibase:timePrecision ?start_precision ] }
@@ -63,7 +63,7 @@ module WikidataPositionHistory
           WHERE {
             ?item wdt:P31 wd:Q5 ; p:P39 ?posn .
             ?posn ps:P39 ?position .
-            ?posn pq:P2937 wd:%s .
+            ?posn pq:P2937 wd:__ITEMID__ .
             FILTER NOT EXISTS { ?posn wikibase:rank wikibase:DeprecatedRank }
 
             OPTIONAL { ?posn pqv:P580 [ wikibase:timeValue ?start_date; wikibase:timePrecision ?start_precision ] }

--- a/lib/sparql/position_query.rb
+++ b/lib/sparql/position_query.rb
@@ -13,11 +13,11 @@ module WikidataPositionHistory
                           ?isPosition ?isLegislator ?isTerm
                           ?isConstituency ?representative_count ?legislature
           WHERE {
-            VALUES ?item { wd:%s }
-            BIND(EXISTS { wd:%s wdt:P279+ wd:Q4164871 } as ?isPosition)
-            BIND(EXISTS { wd:%s wdt:P279+ wd:Q4175034 } as ?isLegislator)
-            BIND(EXISTS { wd:%s wdt:P31/wdt:P279* wd:Q15238777 } as ?isTerm)
-            BIND(EXISTS { wd:%s wdt:P31/wdt:P279* wd:Q192611 } as ?isConstituency)
+            VALUES ?item { wd:__ITEMID__ }
+            BIND(EXISTS { wd:__ITEMID__ wdt:P279+ wd:Q4164871 } as ?isPosition)
+            BIND(EXISTS { wd:__ITEMID__ wdt:P279+ wd:Q4175034 } as ?isLegislator)
+            BIND(EXISTS { wd:__ITEMID__ wdt:P31/wdt:P279* wd:Q15238777 } as ?isTerm)
+            BIND(EXISTS { wd:__ITEMID__ wdt:P31/wdt:P279* wd:Q192611 } as ?isConstituency)
 
             OPTIONAL { ?item p:P571 [ a wikibase:BestRank ;
               psv:P571 [ wikibase:timeValue ?inception; wikibase:timePrecision ?inception_precision ]
@@ -35,10 +35,6 @@ module WikidataPositionHistory
             }
           }
         SPARQL
-      end
-
-      def sparql_args
-        [itemid] * 5
       end
     end
   end


### PR DESCRIPTION
Rather than passing SPARQL queries through `format` and having to count how many times `%s` should be expanded, introduce a magic `__ITEMID__` variable to stand in for the itemid. If any query ever does need to pass any other parameter in, it can still always override or extend this.