### PR TITLE
[refactoring] group all 'OriginItem' classes togther

### DIFF
--- a/lib/wikidata_position_history.rb
+++ b/lib/wikidata_position_history.rb
@@ -2,9 +2,10 @@
 
 require 'query_service'
 require 'sparql/item_query'
-require 'sparql/position_query'
 require 'sparql/bio_query'
 require 'sparql/mandates_query'
+require 'wikidata_position_history/origin_item'
+require 'wikidata_position_history/implied_list'
 require 'wikidata_position_history/checks'
 require 'wikidata_position_history/template'
 require 'wikidata_position_history/output_row'

--- a/lib/wikidata_position_history/implied_list.rb
+++ b/lib/wikidata_position_history/implied_list.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module WikidataPositionHistory
+  # A list made up of both direct and indirect claims, where we
+  # can tell which came from which, when required
+  class ImpliedList
+    def initialize(direct, indirect)
+      @direct = direct
+      @indirect = indirect
+    end
+
+    def empty?
+      all.empty?
+    end
+
+    def all
+      direct | indirect
+    end
+
+    def both
+      direct & indirect
+    end
+
+    def direct_only
+      direct - indirect
+    end
+
+    def indirect_only
+      indirect - direct
+    end
+
+    attr_reader :direct, :indirect
+  end
+end

--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -8,97 +8,6 @@ require_relative 'report/position'
 require_relative 'report/term'
 
 module WikidataPositionHistory
-  # A list made up of both direct and indirect claims, where we
-  # can tell which came from which, when required
-  class ImpliedList
-    def initialize(direct, indirect)
-      @direct = direct
-      @indirect = indirect
-    end
-
-    def empty?
-      all.empty?
-    end
-
-    def all
-      direct | indirect
-    end
-
-    def both
-      direct & indirect
-    end
-
-    def direct_only
-      direct - indirect
-    end
-
-    def indirect_only
-      indirect - direct
-    end
-
-    attr_reader :direct, :indirect
-  end
-
-  # Data about the position itself, to be passed to the report template
-  class Metadata
-    def initialize(rows)
-      @rows = rows
-    end
-
-    def position
-      rows.map(&:item).first
-    end
-
-    def predecessor
-      @predecessor ||= OutputRow::Predecessor.new(self)
-    end
-
-    def successor
-      @successor ||= OutputRow::Successor.new(self)
-    end
-
-    def inception
-      @inception ||= OutputRow::Inception.new(self)
-    end
-
-    def abolition
-      @abolition ||= OutputRow::Abolition.new(self)
-    end
-
-    def type
-      # this should be the same everywhere
-      rows.map(&:type).first
-    end
-
-    def representative_count
-      rows.map(&:representative_count).max
-    end
-
-    def replaces_combined
-      @replaces_combined ||= ImpliedList.new(uniq_by_id(:replaces), uniq_by_id(:derived_replaces))
-    end
-
-    def replaced_by_combined
-      @replaced_by_combined ||= ImpliedList.new(uniq_by_id(:replaced_by), uniq_by_id(:derived_replaced_by))
-    end
-
-    def inception_dates
-      rows.map(&:inception_date).compact.uniq(&:to_s).sort
-    end
-
-    def abolition_dates
-      rows.map(&:abolition_date).compact.uniq(&:to_s).sort
-    end
-
-    private
-
-    attr_reader :rows
-
-    def uniq_by_id(method)
-      rows.map(&method).compact.uniq(&:id).sort_by(&:id)
-    end
-  end
-
   # The entire wikitext generated for this report
   class Report
     def initialize(position_id)
@@ -109,7 +18,7 @@ module WikidataPositionHistory
     attr_reader :position_id, :template_class
 
     def metadata
-      @metadata ||= Metadata.new(SPARQL::PositionQuery.new(position_id).results_as(PositionRow))
+      @metadata ||= OriginItem.new(SPARQL::OriginQuery.new(position_id).results_as(OriginRow))
     end
 
     def report

--- a/test/create_example_data.rb
+++ b/test/create_example_data.rb
@@ -13,6 +13,6 @@ end
 id = ARGV.first or abort "Usage: #{$PROGRAM_NAME} <Qid>"
 report = WikidataPositionHistory::Report.new(id).report
 
-store(id, 'metadata', WikidataPositionHistory::SPARQL::PositionQuery.new(id))
+store(id, 'metadata', WikidataPositionHistory::SPARQL::OriginQuery.new(id))
 store(id, 'mandates', report.send(:sparql))
 store(id, 'biodata', report.send(:biodata_sparql))


### PR DESCRIPTION
Group together all the classes relating to the OriginItem, renaming them
in the process (Position is a bit too ambiguous, especially as some of
the items aren't directly positions, but things like constituencies or
legislative terms)