### PR TITLE
rename Position to Office

### DIFF
--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require_relative 'report/abstract'
-require_relative 'report/legislator'
 require_relative 'report/mandate'
+require_relative 'report/office'
+require_relative 'report/legislator'
 require_relative 'report/constituency'
-require_relative 'report/position'
 require_relative 'report/term'
 
 module WikidataPositionHistory
@@ -27,7 +27,7 @@ module WikidataPositionHistory
         'constituency' => Report::Constituency,
         'term'         => Report::Term,
       }
-      report_class.default = Report::Position
+      report_class.default = Report::Office
       report_class[metadata.type].new(metadata)
     end
 

--- a/lib/wikidata_position_history/report/constituency.rb
+++ b/lib/wikidata_position_history/report/constituency.rb
@@ -8,7 +8,7 @@ module WikidataPositionHistory
         {
           mandates_query_class: SPARQL::ConstituencyMandatesQuery,
           biodata_query_class:  SPARQL::ConstituencyBioQuery,
-          template_class:       ReportTemplate::Position,
+          template_class:       ReportTemplate::Office,
           mandate_class:        MandateRow,
         }
       end

--- a/lib/wikidata_position_history/report/office.rb
+++ b/lib/wikidata_position_history/report/office.rb
@@ -2,13 +2,14 @@
 
 module WikidataPositionHistory
   class Report
-    # The default single-person-at-a-time position
-    class Position < Mandate
+    # A position that is usually held by a single person at a time
+    # (e.g. Executive positions; president, governor, mayor, etc.)
+    class Office < Mandate
       def config
         {
           mandates_query_class: SPARQL::MandatesQuery,
           biodata_query_class:  SPARQL::BioQuery,
-          template_class:       ReportTemplate::Position,
+          template_class:       ReportTemplate::Office,
           mandate_class:        MandateRow,
         }
       end

--- a/lib/wikidata_position_history/template.rb
+++ b/lib/wikidata_position_history/template.rb
@@ -24,5 +24,5 @@ module WikidataPositionHistory
   end
 end
 
-require_relative 'template/position'
+require_relative 'template/office'
 require_relative 'template/term'

--- a/lib/wikidata_position_history/template/office.rb
+++ b/lib/wikidata_position_history/template/office.rb
@@ -2,8 +2,8 @@
 
 module WikidataPositionHistory
   class ReportTemplate
-    # ERB output template for position and constituency types
-    class Position < Base
+    # ERB output template for Office and Constituency types
+    class Office < Base
       def template_text
         <<~ERB
           {| class="wikitable" style="text-align: center; border: none;"


### PR DESCRIPTION
Remove some of the ambiguity around what a 'position' is. This naming
still isn't great, as ideally this would convey better that it's a
"one-person-at-a-time office", but this is still a little better than
just plain 'position'