### PR TITLE
[refactoring] make Mandate report abstract

### DIFF
--- a/lib/wikidata_position_history/report.rb
+++ b/lib/wikidata_position_history/report.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'report/abstract'
-require_relative 'report/mandate'
+require_relative 'report/abstract_mandate'
 require_relative 'report/office'
 require_relative 'report/legislator'
 require_relative 'report/constituency'

--- a/lib/wikidata_position_history/report/abstract_mandate.rb
+++ b/lib/wikidata_position_history/report/abstract_mandate.rb
@@ -2,8 +2,12 @@
 
 module WikidataPositionHistory
   class Report
-    # base report where each row is one person holding an office for a period
-    class Mandate < Abstract
+    # abstract report category, where each row is one person holding an
+    # office for a period. This could either be an executive-style
+    # one-person-at-a-time office (president, mayor, etc) [e.g.
+    # Report::Office], or a legislative-style many-people-at-a-time one
+    # [e.g. Report::Term]
+    class AbstractMandate < Abstract
       def wikitext
         return no_items_output if mandates.empty?
 
@@ -44,10 +48,6 @@ module WikidataPositionHistory
         biodata.select { |bio| bio.person.id == officeholder.id }
       end
 
-      def padded_mandates
-        [nil, mandates, nil].flatten(1)
-      end
-
       def sparql
         @sparql ||= mandates_query_class.new(position_id)
       end
@@ -62,15 +62,6 @@ module WikidataPositionHistory
 
       def no_items_output
         "\n{{PositionHolderHistory/error_no_holders|id=#{position_id}}}\n"
-      end
-
-      def table_rows
-        padded_mandates.each_cons(3).map do |later, current, earlier|
-          {
-            mandate: OutputRow::Mandate.new(later, current, earlier),
-            bio:     biodata_for(current.officeholder),
-          }
-        end
       end
     end
   end

--- a/lib/wikidata_position_history/report/constituency.rb
+++ b/lib/wikidata_position_history/report/constituency.rb
@@ -3,7 +3,7 @@
 module WikidataPositionHistory
   class Report
     # Report of representatives for a single-member consttuency
-    class Constituency < Mandate
+    class Constituency < Office
       def config
         {
           mandates_query_class: SPARQL::ConstituencyMandatesQuery,

--- a/lib/wikidata_position_history/report/office.rb
+++ b/lib/wikidata_position_history/report/office.rb
@@ -4,7 +4,9 @@ module WikidataPositionHistory
   class Report
     # A position that is usually held by a single person at a time
     # (e.g. Executive positions; president, governor, mayor, etc.)
-    class Office < Mandate
+    # The key element here is that we need to compare each officeholder
+    # with others, to check for overlaps, etc.
+    class Office < AbstractMandate
       def config
         {
           mandates_query_class: SPARQL::MandatesQuery,
@@ -12,6 +14,19 @@ module WikidataPositionHistory
           template_class:       ReportTemplate::Office,
           mandate_class:        MandateRow,
         }
+      end
+
+      def table_rows
+        padded_mandates.each_cons(3).map do |later, current, earlier|
+          {
+            mandate: OutputRow::Mandate.new(later, current, earlier),
+            bio:     biodata_for(current.officeholder),
+          }
+        end
+      end
+
+      def padded_mandates
+        [nil, mandates, nil].flatten(1)
       end
     end
   end

--- a/lib/wikidata_position_history/report/term.rb
+++ b/lib/wikidata_position_history/report/term.rb
@@ -3,7 +3,7 @@
 module WikidataPositionHistory
   class Report
     # Report of representatives during a legislative term
-    class Term < Mandate
+    class Term < AbstractMandate
       def config
         {
           mandates_query_class: SPARQL::TermMandatesQuery,


### PR DESCRIPTION
Make the Report tree a little cleaner by emphasising that the 'Mandate' class is abstract, and can be used by either the single-member Office report, or the multi-member Term report, and pushing all the 'look at predecessor and successor' logic specifically into the Office report.