### PR TITLE
Create item_field and date_field metamethods

### DIFF
--- a/lib/sparql/item_query.rb
+++ b/lib/sparql/item_query.rb
@@ -37,14 +37,14 @@ module WikidataPositionHistory
         @row = row
       end
 
-      def self.item_field(method_name)
-        field = method_name.to_s.gsub(/_\w/) { |str| str.delete_prefix('_').upcase }.to_sym
+      def self.item_field(method_name, field = nil)
+        field ||= method_name.to_s.gsub(/_\w/) { |str| str.delete_prefix('_').upcase }
         define_method(method_name) { item_from(field) }
       end
 
-      def self.date_field(method_name)
-        field = method_name.to_s.gsub('_date', '').to_sym
-        precision_field = "#{field}_precision".to_sym
+      def self.date_field(method_name, field = nil, precision_field = nil)
+        field ||= method_name.to_s.gsub('_date', '')
+        precision_field ||= "#{field}_precision"
         define_method(method_name) { date_from(field, precision_field) }
       end
 
@@ -67,7 +67,7 @@ module WikidataPositionHistory
       end
 
       def raw(key)
-        row.dig(key, :value)
+        row.dig(key.to_sym, :value)
       end
     end
   end

--- a/lib/sparql/item_query.rb
+++ b/lib/sparql/item_query.rb
@@ -42,6 +42,12 @@ module WikidataPositionHistory
         define_method(method_name) { item_from(field) }
       end
 
+      def self.date_field(method_name)
+        field = method_name.to_s.gsub('_date', '').to_sym
+        precision_field = "#{field}_precision".to_sym
+        define_method(method_name) { date_from(field, precision_field) }
+      end
+
       protected
 
       attr_reader :row

--- a/lib/sparql/item_query.rb
+++ b/lib/sparql/item_query.rb
@@ -37,6 +37,11 @@ module WikidataPositionHistory
         @row = row
       end
 
+      def self.item_field(method_name)
+        field = method_name.to_s.gsub(/_\w/) { |str| str.delete_prefix('_').upcase }.to_sym
+        define_method(method_name) { item_from(field) }
+      end
+
       protected
 
       attr_reader :row

--- a/lib/wikidata_position_history/checks.rb
+++ b/lib/wikidata_position_history/checks.rb
@@ -17,13 +17,14 @@ module WikidataPositionHistory
 
     attr_reader :later, :current, :earlier
 
-    # TODO: replace these with objects instead of strings
     def successor_qlink
-      current.next
+      successor = current.next or return
+      successor.qlink
     end
 
     def predecessor_qlink
-      current.prev
+      predecessor = current.prev or return
+      predecessor.qlink
     end
 
     def later_holder?

--- a/lib/wikidata_position_history/origin_item.rb
+++ b/lib/wikidata_position_history/origin_item.rb
@@ -51,9 +51,12 @@ module WikidataPositionHistory
   #  (due to combinatorial explosion when multiple values are set for
   #  any property, there could potentially be a large number of rows)
   class OriginRow < SPARQL::QueryRow
-    def item
-      item_from(:item)
-    end
+    item_field :item
+    item_field :replaces
+    item_field :replaced_by
+    item_field :derived_replaces
+    item_field :derived_replaced_by
+    item_field :legislature
 
     def inception_date
       date_from(:inception, :inception_precision)
@@ -63,31 +66,11 @@ module WikidataPositionHistory
       date_from(:abolition, :abolition_precision)
     end
 
-    def replaces
-      item_from(:replaces)
-    end
-
-    def replaced_by
-      item_from(:replacedBy)
-    end
-
-    def derived_replaces
-      item_from(:derivedReplaces)
-    end
-
-    def derived_replaced_by
-      item_from(:derivedReplacedBy)
-    end
-
     def type
       return 'constituency' if raw(:isConstituency) == 'true'
       return 'legislator'   if raw(:isLegislator) == 'true'
       return 'term'         if raw(:isTerm) == 'true'
       return 'position'     if raw(:isPosition) == 'true'
-    end
-
-    def legislature
-      item_from(:legislature)
     end
 
     def representative_count

--- a/lib/wikidata_position_history/origin_item.rb
+++ b/lib/wikidata_position_history/origin_item.rb
@@ -57,14 +57,8 @@ module WikidataPositionHistory
     item_field :derived_replaces
     item_field :derived_replaced_by
     item_field :legislature
-
-    def inception_date
-      date_from(:inception, :inception_precision)
-    end
-
-    def abolition_date
-      date_from(:abolition, :abolition_precision)
-    end
+    date_field :inception_date
+    date_field :abolition_date
 
     def type
       return 'constituency' if raw(:isConstituency) == 'true'

--- a/lib/wikidata_position_history/report/abstract_mandate.rb
+++ b/lib/wikidata_position_history/report/abstract_mandate.rb
@@ -70,9 +70,7 @@ module WikidataPositionHistory
   # The actual SPARQL differs for each type of report, but the fields
   # returned are the same.
   class HumanBioRow < SPARQL::QueryRow
-    def person
-      item_from(:item)
-    end
+    item_field :person, 'item'
 
     def image_title
       return if image_url.to_s.empty?

--- a/lib/wikidata_position_history/report/office.rb
+++ b/lib/wikidata_position_history/report/office.rb
@@ -84,19 +84,11 @@ module WikidataPositionHistory
     item_field :party
     date_field :start_date, 'start_date', 'start_precision'
     date_field :end_date, 'end_date', 'end_precision'
+    item_field :prev
+    item_field :next
 
     def ordinal
       raw(:ordinal)
-    end
-
-    # TODO: switch to item_field
-    def prev
-      QueryService::WikidataItem.new(row.dig(:prev, :value)).qlink
-    end
-
-    # TODO: switch to item_field
-    def next
-      QueryService::WikidataItem.new(row.dig(:next, :value)).qlink
     end
 
     def acting?

--- a/lib/wikidata_position_history/report/office.rb
+++ b/lib/wikidata_position_history/report/office.rb
@@ -80,6 +80,7 @@ module WikidataPositionHistory
   # Represents a single row returned from the OfficeMandates query
   class OfficeMandateRow < SPARQL::QueryRow
     item_field :officeholder, 'item'
+    item_field :nature
     item_field :party
     date_field :start_date, 'start_date', 'start_precision'
     date_field :end_date, 'end_date', 'end_precision'
@@ -98,13 +99,10 @@ module WikidataPositionHistory
       QueryService::WikidataItem.new(row.dig(:next, :value)).qlink
     end
 
-    # TODO: switch to item_field
-    def nature
-      QueryService::WikidataItem.new(row.dig(:nature, :value)).id
-    end
-
     def acting?
-      nature == 'Q4676846'
+      return unless nature
+
+      nature.id == 'Q4676846'
     end
   end
 end

--- a/lib/wikidata_position_history/report/office.rb
+++ b/lib/wikidata_position_history/report/office.rb
@@ -79,43 +79,32 @@ module WikidataPositionHistory
 
   # Represents a single row returned from the OfficeMandates query
   class OfficeMandateRow < SPARQL::QueryRow
+    item_field :officeholder, 'item'
+    item_field :party
+    date_field :start_date, 'start_date', 'start_precision'
+    date_field :end_date, 'end_date', 'end_precision'
+
     def ordinal
       raw(:ordinal)
     end
 
-    def officeholder
-      item_from(:item)
-    end
-
-    def party
-      item_from(:party)
-    end
-
-    # TODO: switch to item_from
+    # TODO: switch to item_field
     def prev
       QueryService::WikidataItem.new(row.dig(:prev, :value)).qlink
     end
 
-    # TODO: switch to item_from
+    # TODO: switch to item_field
     def next
       QueryService::WikidataItem.new(row.dig(:next, :value)).qlink
     end
 
-    # TODO: switch to item_from
+    # TODO: switch to item_field
     def nature
       QueryService::WikidataItem.new(row.dig(:nature, :value)).id
     end
 
     def acting?
       nature == 'Q4676846'
-    end
-
-    def start_date
-      date_from(:start_date, :start_precision)
-    end
-
-    def end_date
-      date_from(:end_date, :end_precision)
     end
   end
 end

--- a/lib/wikidata_position_history/report/term.rb
+++ b/lib/wikidata_position_history/report/term.rb
@@ -70,12 +70,7 @@ module WikidataPositionHistory
 
   # Represents a single row returned from the TermMandates query
   class TermMandateRow < OfficeMandateRow
-    def district
-      QueryService::WikidataItem.new(row.dig(:district, :value))
-    end
-
-    def end_cause
-      QueryService::WikidataItem.new(row.dig(:endCause, :value))
-    end
+    item_field :district
+    item_field :end_cause
   end
 end


### PR DESCRIPTION
When dealing with results from a SPARQL query, make it easier to set up methods to convert result values into Items and Dates.