### PR TITLE
Use specific template for memberless terms

### DIFF
--- a/lib/wikidata_position_history/report/term.rb
+++ b/lib/wikidata_position_history/report/term.rb
@@ -21,6 +21,10 @@ module WikidataPositionHistory
           }
         end
       end
+
+      def no_items_output
+        "\n{{PositionHolderHistory/error_no_term_members|id=#{position_id}}}\n"
+      end
     end
   end
 

--- a/test/example-data/biodata/Q30744183.json
+++ b/test/example-data/biodata/Q30744183.json
@@ -1,0 +1,8 @@
+{
+  "head" : {
+    "vars" : [ "item", "image" ]
+  },
+  "results" : {
+    "bindings" : [ ]
+  }
+}

--- a/test/example-data/mandates/Q30744183.json
+++ b/test/example-data/mandates/Q30744183.json
@@ -1,0 +1,8 @@
+{
+  "head" : {
+    "vars" : [ "item", "start_date", "start_precision", "end_date", "end_precision", "prev", "next", "party", "district", "endCause" ]
+  },
+  "results" : {
+    "bindings" : [ ]
+  }
+}

--- a/test/example-data/metadata/Q30744183.json
+++ b/test/example-data/metadata/Q30744183.json
@@ -1,0 +1,49 @@
+{
+  "head" : {
+    "vars" : [ "item", "inception", "inception_precision", "abolition", "abolition_precision", "replaces", "replacedBy", "derivedReplaces", "derivedReplacedBy", "isPosition", "isLegislator", "isTerm", "isConstituency", "representative_count", "legislature" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30744183"
+      },
+      "isPosition" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isLegislator" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "isTerm" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "true"
+      },
+      "isConstituency" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+        "type" : "literal",
+        "value" : "false"
+      },
+      "replaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30744187"
+      },
+      "replacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1009198"
+      },
+      "derivedReplaces" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30744187"
+      },
+      "derivedReplacedBy" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1009198"
+      }
+    } ]
+  }
+}

--- a/test/wikidata_position_history/report/error_templates_spec.rb
+++ b/test/wikidata_position_history/report/error_templates_spec.rb
@@ -23,4 +23,10 @@ describe WikidataPositionHistory::Report do
     it { expect(report.send(:metadata).representative_count).must_equal 12 }
     it { expect(report.wikitext[/{{(.*?)}}/, 1]).must_include 'error_multimember' }
   end
+
+  describe 'warning template for term with no members' do
+    let(:report) { WikidataPositionHistory::Report.new('Q30744183') }
+
+    it { expect(report.wikitext[/{{(.*?)}}/, 1]).must_include 'error_no_term_members|id=Q30744183' }
+  end
 end


### PR DESCRIPTION
If a term report cannot find any members, use a template specific to this scenario, rather than the generic no-holders template, so it can give more specific information about how to fix this.